### PR TITLE
feat: skip CI for documentation-only changes

### DIFF
--- a/.github/scripts/check-changed-files.js
+++ b/.github/scripts/check-changed-files.js
@@ -1,0 +1,42 @@
+/**
+ * Check if PR contains only documentation changes
+ * @param {Object} github - GitHub API client
+ * @param {Object} context - GitHub Actions context
+ * @param {Object} core - GitHub Actions core
+ * @param {Array<string>} skipExtensions - File extensions that should skip CI
+ * @returns {Promise<boolean>} - true if CI should run, false if should skip
+ */
+module.exports = async ({ github, context, core, skipExtensions = ['.md', '.txt'] }) => {
+  const { data: files } = await github.rest.pulls.listFiles({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+  });
+
+  console.log(`📊 Total files changed in PR: ${files.length}`);
+  console.log('📁 All changed files:');
+  files.forEach(f => console.log(`  - ${f.filename} (${f.status})`));
+
+  // Check if ALL files match skip extensions
+  const allFilesAreSkippable = files.every(f =>
+    skipExtensions.some(ext => f.filename.endsWith(ext))
+  );
+
+  const hasChanges = !allFilesAreSkippable;
+  core.setOutput('has-changes', hasChanges ? 'true' : 'false');
+
+  if (hasChanges) {
+    console.log('\n✅ Code changes detected - CI will run');
+    const codeFiles = files.filter(f =>
+      !skipExtensions.some(ext => f.filename.endsWith(ext))
+    );
+    console.log(`🔧 Files requiring CI validation (${codeFiles.length}):`);
+    codeFiles.forEach(f => console.log(`  - ${f.filename}`));
+  } else {
+    console.log('\n⏭️  Only skippable files changed - CI will be skipped');
+    console.log(`📝 All files match skip extensions: ${skipExtensions.join(', ')}`);
+    console.log('💡 All validation jobs will be skipped');
+  }
+
+  return hasChanges;
+};

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,8 +17,32 @@ permissions:
   contents: read       # Required for checkout
 
 jobs:
+  check-code-changes:
+    name: Check Code Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has-changes: ${{ steps.check.outputs.has-changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for documentation-only changes
+        uses: actions/github-script@v7
+        id: check
+        with:
+          script: |
+            const checkChangedFiles = require('./.github/scripts/check-changed-files.js');
+            return await checkChangedFiles({
+              github,
+              context,
+              core,
+              skipExtensions: ['.md', '.txt']
+            });
+
   validate-ktlint:
     name: Validate Ktlint
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,6 +56,8 @@ jobs:
 
   validate-detekt:
     name: Validate Detekt
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,6 +71,8 @@ jobs:
 
   validate-spotless:
     name: Validate Spotless
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,6 +86,8 @@ jobs:
 
   validate-licenses:
     name: Validate Licenses
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -71,6 +101,8 @@ jobs:
 
   validate-api:
     name: Validate API
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -84,6 +116,8 @@ jobs:
 
   run-tests:
     name: Run Tests
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -97,6 +131,8 @@ jobs:
 
   test-samples:
     name: Test Samples
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -107,3 +143,39 @@ jobs:
 
       - name: Run Sample Tests
         uses: ./.github/actions/test-samples
+
+  ci-summary:
+    name: CI Summary
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - check-code-changes
+      - validate-ktlint
+      - validate-detekt
+      - validate-spotless
+      - validate-licenses
+      - validate-api
+      - run-tests
+      - test-samples
+    steps:
+      - name: Check CI status
+        run: |
+          if [[ "${{ needs.check-code-changes.outputs.has-changes }}" == "false" ]]; then
+            echo "✅ Documentation-only changes - all jobs skipped successfully"
+            exit 0
+          fi
+
+          # Check if any job failed
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "❌ Some CI jobs failed"
+            exit 1
+          fi
+
+          # Check if any job was cancelled
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "⚠️  Some CI jobs were cancelled"
+            exit 1
+          fi
+
+          echo "✅ All CI jobs passed successfully"
+          exit 0


### PR DESCRIPTION
## Description

Implements smart file change detection to skip CI validation jobs when only documentation files (`.md`, `.txt`) are modified.

**Strategy:**
- New `check-code-changes` job checks file extensions via GitHub API
- If ALL changed files are `.md` or `.txt` → skip validations
- If ANY file is code → run full CI
- `ci-summary` job always runs and ensures required checks pass

**Benefits:**
- Documentation PRs complete in ~30s (vs ~5-10min before)
- Reduced CI costs and resource usage
- Workflow changes (`.yml`) still trigger full CI

## Related Issue

N/A - Agile development improvement

## Type of Change

- [x] Refactor/Performance/Build
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply` (N/A - YAML/JS only)
- [x] Linter passing: `./gradlew lintKotlin` (N/A - no Kotlin code)
- [x] Static analysis: `./gradlew detekt` (N/A - no Kotlin code)
- [x] Tests added/updated and passing: `./gradlew test` (N/A - CI workflow)
- [x] Generated code compiles (verified with sample project) (N/A)
- [x] Updated documentation if needed (N/A)
- [x] No breaking changes OR breaking changes documented (✅ No breaking changes)
