### PR TITLE
chore: bump version to 1.0.0-alpha03

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -76,7 +76,7 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         public const val PLUGIN_ID: String = "com.rsicarelli.fakt"
         public const val PLUGIN_ARTIFACT_NAME: String = "compiler"
         public const val PLUGIN_GROUP_ID: String = "com.rsicarelli.fakt"
-        public const val PLUGIN_VERSION: String = "1.0.0-alpha02"
+        public const val PLUGIN_VERSION: String = "1.0.0-alpha03"
     }
 
     @OptIn(ExperimentalFaktMultiModule::class)

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ ksp.version.check=false
 
 # Project Coordinates
 group=com.rsicarelli.fakt
-version=1.0.0-alpha02
+version=1.0.0-alpha03
 
 # POM Metadata
 POM_NAME=Fakt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@
 
 [versions]
 # Fakt version (auto-synced with gradle.properties:VERSION_NAME)
-fakt = "1.0.0-alpha02"
+fakt = "1.0.0-alpha03"
 android-gradle-plugin = "8.12.3"
 binaryCompatibilityValidator = "0.18.1"
 detekt = "1.23.8"


### PR DESCRIPTION
## Summary
- Bump version from `1.0.0-alpha02` to `1.0.0-alpha03`
- alpha02 was burned due to Maven Central issue

## Changes
- `gradle.properties` - main version
- `gradle/libs.versions.toml` - version catalog
- `FaktGradleSubplugin.kt` - plugin version constant