### PR TITLE
fix(docs): prevent snapshots from being default docs version

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -86,6 +86,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/deploy-docs.yml
     with:
-      version: ${{ needs.publish-snapshot.outputs.snapshot_version }}
+      version: 'snapshot'
       alias: 'snapshot'
-      set-default: true
+      set-default: false


### PR DESCRIPTION
## Summary

- Use fixed `snapshot` version name instead of dynamic version string (e.g., `1.0.0-alpha03-SNAPSHOT`)
- Set `set-default: false` so stable releases remain the default documentation

## Problem

When visiting https://rsicarelli.github.io/fakt/, users were redirected to `/snapshot/` instead of the latest stable release. Additionally, multiple snapshot versions were accumulating in the version selector.

## Solution

1. **Fixed version name**: Changed from `${{ needs.publish-snapshot.outputs.snapshot_version }}` to `'snapshot'` - this overwrites the same entry instead of creating new ones
2. **Disabled default**: Changed `set-default: true` to `set-default: false` - stable releases now remain as default

## After Merging

Trigger the "Publish Release" workflow to set the latest stable version as default.