### PR TITLE
fix(docs): make alias optional for snapshot deployments

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -87,5 +87,4 @@ jobs:
     uses: ./.github/workflows/deploy-docs.yml
     with:
       version: 'snapshot'
-      alias: 'snapshot'
       set-default: false

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,9 +9,10 @@ on:
         type: string
         description: 'Version to deploy (e.g., 1.0.0, 1.0.0-SNAPSHOT)'
       alias:
-        required: true
+        required: false
         type: string
-        description: 'Alias for this version (snapshot or latest)'
+        default: ''
+        description: 'Alias for this version (e.g., latest). Optional for self-descriptive versions like snapshot'
       set-default:
         required: false
         type: boolean
@@ -29,7 +30,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy ${{ inputs.alias }} documentation
+    name: Deploy ${{ inputs.alias || inputs.version }} documentation
     runs-on: ubuntu-latest
 
     steps:
@@ -63,11 +64,13 @@ jobs:
 
       - name: Deploy documentation with mike
         run: |
-          mike deploy --update-aliases --push \
-            ${{ inputs.version }} \
-            ${{ inputs.alias }}
+          if [ -n "${{ inputs.alias }}" ]; then
+            mike deploy --update-aliases --push ${{ inputs.version }} ${{ inputs.alias }}
+          else
+            mike deploy --push ${{ inputs.version }}
+          fi
 
       - name: Set default version
         if: inputs.set-default
         run: |
-          mike set-default --push ${{ inputs.alias }}
+          mike set-default --push ${{ inputs.alias || inputs.version }}


### PR DESCRIPTION
## Summary

- Make `alias` input optional in `deploy-docs.yml`
- Remove `alias` from `continuous-deploy.yml` for snapshots

## Problem

PR #11 changed snapshot deployments to use `version: 'snapshot'` and `alias: 'snapshot'`, but Mike doesn't allow version and alias to be identical:

```
error: duplicated version and alias
```

## Solution

Snapshots don't need an alias since `snapshot` is already self-descriptive. This PR makes alias optional and removes it from snapshot deployments.

| Workflow | version | alias | Result |
|----------|---------|-------|--------|
| Snapshots | `snapshot` | _(none)_ | `mike deploy --push snapshot` |
| Releases | `1.0.0-alpha03` | `latest` | `mike deploy --update-aliases --push 1.0.0-alpha03 latest` |