### PR TITLE
docs(readme): simplify mascot section intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ assertEquals(1, fake.trackCallCount.value)
 
 ## 🐜 Our Mascot
 
-Meet our mascot, the [Tamandua](https://en.wikipedia.org/wiki/Tamandua)! Just like they eat bugs in nature, Fakt catches drift bugs at compile-time before they reach production.
+The [Tamandua](https://en.wikipedia.org/wiki/Tamandua) eats bugs in nature. Fakt catches drift bugs at compile-time before they reach production.
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove "Meet our mascot" phrasing for a more direct introduction
- Simplifies the Tamandua mascot section to two parallel statements

## Changes

**Before:**
> Meet our mascot, the Tamandua! Just like they eat bugs in nature, Fakt catches drift bugs at compile-time before they reach production.

**After:**
> The Tamandua eats bugs in nature. Fakt catches drift bugs at compile-time before they reach production.

## Test plan

- [x] Verify README renders correctly on GitHub