### PR TITLE
chore: update Wasm/JS package lock

### DIFF
--- a/kotlin-js-store/package-lock.json
+++ b/kotlin-js-store/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakt",
-  "version": "1.0.0-alpha02",
+  "version": "1.0.0-alpha03",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakt",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "workspaces": [
         "packages/fakt-annotations",
         "packages/fakt-annotations-test"
@@ -5378,7 +5378,7 @@
       }
     },
     "packages/fakt-annotations": {
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "devDependencies": {
         "kotlin-web-helpers": "2.1.0",
         "source-map-loader": "5.0.0",
@@ -5389,7 +5389,7 @@
       }
     },
     "packages/fakt-annotations-test": {
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "devDependencies": {
         "karma": "6.4.4",
         "karma-chrome-launcher": "3.2.0",

--- a/kotlin-js-store/wasm/package-lock.json
+++ b/kotlin-js-store/wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakt",
-  "version": "1.0.0-alpha02",
+  "version": "1.0.0-alpha03",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakt",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "workspaces": [
         "packages/fakt-annotations",
         "packages/fakt-annotations-test"
@@ -26,7 +26,7 @@
       "devDependencies": {}
     },
     "packages/fakt-annotations-test": {
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "devDependencies": {}
     },
     "packages/fakt-runtime": {


### PR DESCRIPTION
## Description
Updates Wasm/JS package lock after version update, which was preventing publication


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [ ] Code formatted: `./gradlew spotlessApply`
- [ ] Linter passing: `./gradlew lintKotlin`
- [ ] Static analysis: `./gradlew detekt`
- [ ] Tests added/updated and passing: `./gradlew test`
- [ ] Generated code compiles (verified with sample project)
- [ ] Updated documentation if needed
- [ ] No breaking changes OR breaking changes documented

**Shortcut (if using Makefile):** `make format && make test`

## Additional Context
<!-- Screenshots, notes for reviewers, etc. -->
