### PR TITLE
docs: clarify guideline-based skills usage and simplify pr-creator

### DIFF
--- a/.claude/hooks/skill-activation-prompt.ts
+++ b/.claude/hooks/skill-activation-prompt.ts
@@ -159,8 +159,8 @@ async function main() {
                 output += '\n';
             }
 
-            output += '💡 TIP: Follow the guidelines in .claude/skills/ for these skills\n';
-            output += '   These are guideline-based skills - apply their patterns automatically\n';
+            output += '💡 ACTION: Read .claude/skills/{category}/{skill-name}/SKILL.md and apply guidelines\n';
+            output += '   Do NOT use Skill tool or /commands - these are guideline-based skills\n';
             output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n';
 
             // Output to stdout (will be injected into Claude's context)

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -361,23 +361,17 @@ Simply write natural prompts and skills will auto-suggest:
 
 ### Manual Invocation
 
-Use the Skill tool directly:
+Ask Claude to apply the skill guidelines:
 
-```bash
-# In Claude Code conversation
-Use the Skill tool with "kotlin-api-consultant"
-Use the Skill tool with "compilation-validator"
+```
+"Apply git-commit-guardian guidelines"
+"Use kotlin-api-consultant skill"
+"Follow the bdd-test-runner skill"
 ```
 
-### From Slash Commands
+Claude will automatically read the `.claude/skills/{category}/{skill-name}/SKILL.md` file and apply the guidelines.
 
-Many slash commands automatically use skills:
-
-```bash
-/run-bdd-tests          # Uses: bdd-test-runner
-/validate-compilation   # Uses: compilation-validator
-/consult-kotlin-api     # Uses: kotlin-api-consultant
-```
+**Important**: These are guideline-based skills, NOT registered slash commands or Skill tool invocations. They work by Claude reading and following the SKILL.md documentation.
 
 ---
 

--- a/.claude/skills/core-workflows/pr-creator/SKILL.md
+++ b/.claude/skills/core-workflows/pr-creator/SKILL.md
@@ -55,24 +55,7 @@ git diff main..HEAD --name-only
 - No commits ahead of main
 - Uncommitted changes exist (warn and offer to commit first)
 
-### 3. Ask User for Depth Level (REQUIRED)
-
-**Always prompt before proceeding:**
-
-```
-Which depth level for this PR description?
-
-1. Quick     - Small changes, typos, docs (brief one-liner)
-2. Standard  - Most PRs (2-3 sentences, full checklist)
-3. Comprehensive - Major features, breaking changes (detailed)
-```
-
-**Use AskUserQuestion tool with options:**
-- Quick (Level 1)
-- Standard (Level 2)
-- Comprehensive (Level 3)
-
-### 4. Analyze Changes
+### 3. Analyze Changes
 
 **Determine PR characteristics:**
 
@@ -102,7 +85,7 @@ Which depth level for this PR description?
 - Extract from branch name: `fix/123-description` → #123
 - Extract from commit messages: `Fixes #456`
 
-### 5. Generate PR Title
+### 4. Generate PR Title
 
 **Apply Conventional Commits format:**
 
@@ -125,32 +108,14 @@ docs: update KMP multi-module guide
 refactor(generation)!: restructure factory generation API
 ```
 
-### 6. Populate PR Template
+### 5. Populate PR Template
 
 **Read project template:**
 ```bash
 cat .github/pull_request_template.md
 ```
 
-**Fill sections based on depth level:**
-
-#### Level 1: Quick
-```markdown
-## Description
-{One-liner from commit message or change summary}
-
-## Related Issue
-{Extracted issue or "N/A"}
-
-## Type of Change
-- [x] {Detected type}
-
-## Pre-Submission Checklist
-- [x] Code formatted
-- [x] Tests passing
-```
-
-#### Level 2: Standard
+**Always use Standard format:**
 ```markdown
 ## Description
 {2-3 sentences explaining what changed and why}
@@ -174,47 +139,7 @@ Fixes #{issue}
 {Key implementation details or decisions}
 ```
 
-#### Level 3: Comprehensive
-```markdown
-## Description
-{Detailed explanation:}
-- What problem this solves
-- How it's implemented
-- Key design decisions
-- Migration notes (if breaking)
-
-## Related Issue
-Fixes #{primary_issue}
-Relates to #{related_issues}
-
-## Type of Change
-- [x] {Detected type}
-- [x] Breaking change (if applicable)
-
-## Pre-Submission Checklist
-- [x] Code formatted: `./gradlew spotlessApply`
-- [x] Linter passing: `./gradlew lintKotlin`
-- [x] Static analysis: `./gradlew detekt`
-- [x] Tests added/updated and passing: `./gradlew test`
-- [x] Generated code compiles (verified with sample project)
-- [x] Updated documentation if needed
-- [x] No breaking changes OR breaking changes documented
-
-**Shortcut (if using Makefile):** `make format && make test`
-
-## Additional Context
-{Comprehensive details:}
-- Architecture considerations
-- Performance implications
-- Future work planned
-- Screenshots/examples if relevant
-
-## Breaking Changes
-{If breaking: detailed migration guide}
-{If not breaking: remove this section}
-```
-
-### 7. Validate Before Submission
+### 6. Validate Before Submission
 
 **Check PR is ready:**
 
@@ -234,7 +159,7 @@ make format 2>/dev/null || ./gradlew spotlessCheck
 - Uncommitted changes exist
 - Format check fails
 
-### 8. Create Draft PR
+### 7. Create Draft PR
 
 **Always use draft mode:**
 
@@ -253,7 +178,7 @@ EOF
 - `--title` - Validated Conventional Commits title
 - `--body` - Populated template with proper depth
 
-### 9. Output PR URL and Next Steps
+### 8. Output PR URL and Next Steps
 
 **Success output:**
 


### PR DESCRIPTION
## Description

Clarify how guideline-based skills work in the Fakt project. The hook now explicitly instructs Claude to read SKILL.md files instead of attempting to use the Skill tool or /commands (which don't work for guideline-based skills).

Also simplifies the pr-creator skill by removing the depth level prompt - now always uses Standard format since that's what most PRs need.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

**Changes:**
- `.claude/hooks/skill-activation-prompt.ts`: Explicit instruction to read SKILL.md, not use Skill tool
- `.claude/skills/README.md`: Fixed "Manual Invocation" section
- `.claude/skills/core-workflows/pr-creator/SKILL.md`: Removed depth level prompt, always use Standard