### PR TITLE
ci: simplify release title and remove auto-prerelease detection

### DIFF
--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -16,27 +16,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Detect pre-release from tag
-      id: detect-prerelease
-      shell: bash
-      run: |
-        TAG="${{ inputs.tag }}"
-        if [[ "$TAG" == *"-rc"* ]] || [[ "$TAG" == *"-alpha"* ]] || [[ "$TAG" == *"-beta"* ]]; then
-          echo "prerelease=true" >> $GITHUB_OUTPUT
-        else
-          echo "prerelease=${{ inputs.is-prerelease }}" >> $GITHUB_OUTPUT
-        fi
-
     - name: Create GitHub Release
       shell: bash
       run: |
         PRERELEASE_FLAG=""
-        if [[ "${{ steps.detect-prerelease.outputs.prerelease }}" == "true" ]]; then
+        if [[ "${{ inputs.is-prerelease }}" == "true" ]]; then
           PRERELEASE_FLAG="--prerelease"
         fi
 
         gh release create "${{ inputs.tag }}" \
-          --title "Release ${{ inputs.tag }}" \
+          --title "${{ inputs.tag }}" \
           --generate-notes \
           $PRERELEASE_FLAG
       env:


### PR DESCRIPTION
## Description

Simplifies GitHub release configuration:
- **Title**: Removes "Release " prefix so releases show as `v1.0.0-alpha05` instead of `Release v1.0.0-alpha05`
- **Pre-release**: Removes automatic pre-release detection based on tag suffixes (alpha/beta/rc). Releases now default to "latest" unless explicitly marked as pre-release via the `is-prerelease` input.

## Related Issue

N/A - User request for cleaner release naming

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

Before: `Release v1.0.0-alpha04` (pre-release)
After: `v1.0.0-alpha04` (latest release)