### PR TITLE
refactor(codegen): unify code generation to DSL approach

### DIFF
--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/ClassBuilder.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/ClassBuilder.kt
@@ -92,7 +92,20 @@ public class ClassBuilder
             name: String,
             vararg arguments: String,
         ) {
-            annotations.add(CodeAnnotation(name, arguments.toList()))
+            annotation(name, arguments.toList())
+        }
+
+        /**
+         * Adds an annotation with a list of arguments (avoids spread operator overhead).
+         *
+         * @param name Annotation simple name
+         * @param arguments Pre-rendered argument strings
+         */
+        public fun annotation(
+            name: String,
+            arguments: List<String>,
+        ) {
+            annotations.add(CodeAnnotation(name, arguments))
         }
 
         /**

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/DataClassBuilder.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/DataClassBuilder.kt
@@ -79,7 +79,20 @@ public class DataClassBuilder
             name: String,
             vararg arguments: String,
         ) {
-            annotations.add(CodeAnnotation(name, arguments.toList()))
+            annotation(name, arguments.toList())
+        }
+
+        /**
+         * Adds an annotation with a list of arguments (avoids spread operator overhead).
+         *
+         * @param name Annotation simple name
+         * @param arguments Pre-rendered argument strings
+         */
+        public fun annotation(
+            name: String,
+            arguments: List<String>,
+        ) {
+            annotations.add(CodeAnnotation(name, arguments))
         }
 
         /**

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/FunctionBuilder.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/FunctionBuilder.kt
@@ -52,6 +52,21 @@ public class FunctionBuilder
         public var isInline: Boolean = false
 
         /**
+         * Optional KDoc documentation for the function.
+         *
+         * Example:
+         * ```kotlin
+         * kdoc = """
+         *     Creates a fake implementation of [UserService] for testing.
+         *
+         *     @param configure DSL block to configure fake behaviors
+         *     @return Configured fake instance
+         * """.trimIndent()
+         * ```
+         */
+        public var kdoc: String? = null
+
+        /**
          * Sets function body as raw code string (block style).
          *
          * Example:
@@ -137,20 +152,23 @@ public class FunctionBuilder
          * ```kotlin
          * typeParam("T")  // fun <T> method()
          * typeParam("R", "Comparable<R>")  // fun <R : Comparable<R>> method()
+         * typeParam("T", reified = true)  // inline fun <reified T> method()
          * ```
          *
          * @param name Type parameter name
          * @param constraints Optional type constraints
+         * @param reified Whether this is a reified type parameter (requires inline function)
          */
         public fun typeParam(
             name: String,
             vararg constraints: String,
+            reified: Boolean = false,
         ) {
             typeParameters.add(
                 CodeTypeParameter(
                     name = name,
                     constraints = constraints.toList(),
-                    isReified = false,
+                    isReified = reified,
                 ),
             )
         }
@@ -236,7 +254,20 @@ public class FunctionBuilder
             name: String,
             vararg arguments: String,
         ) {
-            annotations.add(CodeAnnotation(name, arguments.toList()))
+            annotation(name, arguments.toList())
+        }
+
+        /**
+         * Adds an annotation with a list of arguments (avoids spread operator overhead).
+         *
+         * @param name Annotation simple name
+         * @param arguments Pre-rendered argument strings
+         */
+        public fun annotation(
+            name: String,
+            arguments: List<String>,
+        ) {
+            annotations.add(CodeAnnotation(name, arguments))
         }
 
         private var whereClause: String? = null
@@ -276,5 +307,6 @@ public class FunctionBuilder
                 receiverType = receiverType,
                 annotations = annotations,
                 whereClause = whereClause,
+                kdoc = kdoc,
             )
     }

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/PropertyBuilder.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/builder/PropertyBuilder.kt
@@ -123,7 +123,20 @@ public class PropertyBuilder
             name: String,
             vararg arguments: String,
         ) {
-            annotations.add(CodeAnnotation(name, arguments.toList()))
+            annotation(name, arguments.toList())
+        }
+
+        /**
+         * Adds an annotation with a list of arguments (avoids spread operator overhead).
+         *
+         * @param name Annotation simple name
+         * @param arguments Pre-rendered argument strings
+         */
+        public fun annotation(
+            name: String,
+            arguments: List<String>,
+        ) {
+            annotations.add(CodeAnnotation(name, arguments))
         }
 
         /**

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/FactoryExtensions.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/FactoryExtensions.kt
@@ -2,11 +2,92 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.rsicarelli.fakt.codegen.extensions
 
+import com.rsicarelli.fakt.codegen.builder.codeFile
+import com.rsicarelli.fakt.codegen.model.CodeFile
+import com.rsicarelli.fakt.codegen.model.CodeFunction
+import com.rsicarelli.fakt.codegen.renderer.CodeBuilder
+import com.rsicarelli.fakt.codegen.renderer.renderTo
 import com.rsicarelli.fakt.compiler.fir.metadata.FirVisibility
-import com.rsicarelli.fakt.compiler.fir.metadata.toModifier
+
+/**
+ * Generates a factory function CodeFile for creating fake implementations.
+ *
+ * Uses type-safe DSL for clean, composable code generation.
+ * The returned CodeFile contains only the function declaration (no package/imports),
+ * suitable for being added to an existing file.
+ *
+ * @param spec Configuration for the factory function
+ * @param includeKDoc Whether to include KDoc documentation (default: true)
+ * @return CodeFile containing the factory function
+ */
+fun generateFactoryFunctionCodeFile(
+    spec: FactoryFunctionSpec,
+    includeKDoc: Boolean = true,
+): CodeFile {
+    val names = FactoryNames(spec.interfaceName, spec.typeParameters)
+    val (headerParams, whereClause) = parseTypeParametersForFactory(spec.typeParameters)
+    val propagatedAnnotations = spec.annotations.filterPropagatable()
+
+    return codeFile("") {
+        function(names.factoryName) {
+            // Apply visibility
+            when (spec.visibility) {
+                FirVisibility.PUBLIC -> public()
+                FirVisibility.INTERNAL -> internal()
+                else -> public()
+            }
+
+            isInline = true
+
+            // Add type parameters with reified
+            headerParams.forEach { param ->
+                val parts = param.split(" : ", limit = 2)
+                val name = parts[0].trim()
+                val constraint = if (parts.size > 1) parts[1].trim() else null
+                if (constraint != null) {
+                    typeParam(name, constraint, reified = true)
+                } else {
+                    typeParam(name, reified = true)
+                }
+            }
+
+            // Add where clause if needed
+            if (whereClause.isNotEmpty()) {
+                where(whereClause)
+            }
+
+            // Add configure parameter
+            parameter(
+                name = "configure",
+                type = "${names.configClassName}${names.typeArgs}.() -> Unit",
+                defaultValue = "{}",
+            )
+
+            // Set return type
+            returns("${names.fakeClassName}${names.typeArgs}")
+
+            // Set expression body
+            val impl = "${names.fakeClassName}${names.typeArgs}()"
+            val config = "${names.configClassName}${names.typeArgs}(this)"
+            expressionBody = "$impl.apply { $config.configure() }"
+
+            // Add KDoc if requested
+            if (includeKDoc) {
+                kdoc = generateFactoryKDocContent(spec, names)
+            }
+
+            // Add propagated annotations
+            propagatedAnnotations.forEach { annotation ->
+                annotation(annotation.simpleName, annotation.arguments)
+            }
+        }
+    }
+}
 
 /**
  * Generates a factory function string for creating fake implementations.
+ *
+ * This delegates to the DSL-based implementation and renders the result to a string.
  *
  * @param spec Configuration for the factory function
  * @param includeKDoc Whether to include KDoc documentation (default: true)
@@ -16,22 +97,47 @@ fun generateFactoryFunction(
     spec: FactoryFunctionSpec,
     includeKDoc: Boolean = true,
 ): String {
-    val names = FactoryNames(spec.interfaceName, spec.typeParameters)
-    val (headerParams, whereClause) = parseTypeParametersForFactory(spec.typeParameters)
-    val propagatedAnnotations = spec.annotations.filterPropagatable()
+    val codeFile = generateFactoryFunctionCodeFile(spec, includeKDoc)
 
-    return buildString {
-        if (includeKDoc) appendKDoc(spec, names)
-        appendAnnotations(propagatedAnnotations)
-        appendSignature(names, headerParams, spec.visibility)
-        appendBody(names, whereClause)
-    }
+    // Extract the function declaration and render it
+    val function =
+        codeFile.declarations.firstOrNull() as? CodeFunction
+            ?: return ""
+
+    val builder = CodeBuilder()
+    function.renderTo(builder)
+    return builder.build().trimEnd()
 }
 
 /**
  * Overload for common use cases without KDoc customization.
  */
 fun generateFactoryFunction(spec: FactoryFunctionSpec): String = generateFactoryFunction(spec, includeKDoc = true)
+
+/**
+ * Generates KDoc content (without comment markers) for factory function.
+ */
+private fun generateFactoryKDocContent(
+    spec: FactoryFunctionSpec,
+    names: FactoryNames,
+): String {
+    val fullKDoc =
+        KDocGenerator.generateFactoryKDoc(
+            interfaceName = spec.interfaceName,
+            factoryName = names.factoryName,
+            implClassName = names.fakeClassName,
+            methods = spec.methods,
+            properties = spec.properties,
+        )
+    // Remove the /** and */ markers and leading " * " from each line
+    return fullKDoc
+        .lines()
+        .drop(1) // Remove opening /**
+        .dropLast(1) // Remove closing */
+        .joinToString("\n") { line ->
+            line.removePrefix(" * ").removePrefix(" *")
+        }.trim()
+}
 
 private data class FactoryNames(
     val interfaceName: String,
@@ -49,58 +155,6 @@ private fun List<AnnotationSpec>.filterPropagatable() =
     filter {
         (it.simpleName == "OptIn" || it.simpleName == "Deprecated") && !it.isOptInMarker
     }
-
-private fun StringBuilder.appendKDoc(
-    spec: FactoryFunctionSpec,
-    names: FactoryNames,
-) {
-    val kdoc =
-        KDocGenerator.generateFactoryKDoc(
-            interfaceName = spec.interfaceName,
-            factoryName = names.factoryName,
-            implClassName = names.fakeClassName,
-            methods = spec.methods,
-            properties = spec.properties,
-        )
-    appendLine(kdoc)
-}
-
-private fun StringBuilder.appendAnnotations(annotations: List<AnnotationSpec>) {
-    annotations.forEach { annotation ->
-        val argsStr = if (annotation.arguments.isEmpty()) "" else "(${annotation.arguments.joinToString(", ")})"
-        appendLine("@${annotation.simpleName}$argsStr")
-    }
-}
-
-private fun StringBuilder.appendSignature(
-    names: FactoryNames,
-    headerParams: List<String>,
-    visibility: FirVisibility,
-) {
-    if (names.hasGenerics) {
-        val typeParamsStr =
-            headerParams.joinToString(", ") { param ->
-                val parts = param.split(" : ")
-                if (parts.size > 1) "reified ${parts[0]} : ${parts[1]}" else "reified $param"
-            }
-        append("${visibility.toModifier()}inline fun <$typeParamsStr> ${names.factoryName}")
-    } else {
-        append("${visibility.toModifier()}inline fun ${names.factoryName}")
-    }
-    append("(configure: ${names.configClassName}${names.typeArgs}.() -> Unit = {})")
-    append(": ${names.fakeClassName}${names.typeArgs}")
-}
-
-private fun StringBuilder.appendBody(
-    names: FactoryNames,
-    whereClause: String,
-) {
-    if (whereClause.isNotEmpty()) append(" where $whereClause")
-    appendLine(" =")
-    val impl = "${names.fakeClassName}${names.typeArgs}()"
-    val config = "${names.configClassName}${names.typeArgs}(this)"
-    append("    $impl.apply { $config.configure() }")
-}
 
 /**
  * Parses type parameters for factory function generation.

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/model/CodeFile.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/model/CodeFile.kt
@@ -174,6 +174,7 @@ data class DataClassProperty(
  * @property isInline Whether this is an inline function
  * @property receiverType Extension receiver type for extension functions (e.g., Vector for fun Vector.plus())
  * @property annotations Function-level annotations (e.g., @Suppress)
+ * @property kdoc Optional KDoc documentation for the function
  */
 data class CodeFunction(
     val name: String,
@@ -187,6 +188,7 @@ data class CodeFunction(
     val receiverType: CodeType? = null,
     val annotations: List<CodeAnnotation> = emptyList(),
     val whereClause: String? = null,
+    val kdoc: String? = null,
 ) : CodeDeclaration,
     CodeMember
 

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/renderer/Rendering.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/renderer/Rendering.kt
@@ -287,11 +287,13 @@ public fun CodeAnnotation.renderAsFileAnnotation(builder: CodeBuilder) {
 /**
  * Renders [CodeFunction] to [CodeBuilder].
  *
- * Generates complete function signature and body.
+ * Generates complete function signature and body, with optional KDoc.
  *
  * @param builder The [CodeBuilder] to write to
  */
 public fun CodeFunction.renderTo(builder: CodeBuilder) {
+    // Render KDoc if present
+    kdoc?.let { renderKDoc(builder, it) }
     annotations.forEach { it.renderTo(builder) }
     val signature = buildFunctionSignature()
     when (body) {
@@ -299,6 +301,33 @@ public fun CodeFunction.renderTo(builder: CodeBuilder) {
         is CodeBlock.Statements -> renderStatementsBody(builder, signature)
         CodeBlock.Empty -> builder.appendLine(signature.full)
     }
+}
+
+/**
+ * Renders KDoc content to the builder.
+ *
+ * KDoc is rendered as a multi-line comment with proper formatting:
+ * ```
+ * /**
+ *  * First line
+ *  * Second line
+ *  */
+ * ```
+ */
+private fun renderKDoc(
+    builder: CodeBuilder,
+    kdoc: String,
+) {
+    val lines = kdoc.lines()
+    builder.appendLine("/**")
+    lines.forEach { line ->
+        if (line.isBlank()) {
+            builder.appendLine(" *")
+        } else {
+            builder.appendLine(" * $line")
+        }
+    }
+    builder.appendLine(" */")
 }
 
 private fun CodeFunction.buildFunctionSignature(): FunctionSignature {

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/ir/generation/CodeGenerator.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/ir/generation/CodeGenerator.kt
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.rsicarelli.fakt.compiler.ir.generation
 
+import com.rsicarelli.fakt.codegen.model.CodeFile
 import com.rsicarelli.fakt.codegen.renderer.CodeBuilder
 import com.rsicarelli.fakt.codegen.renderer.renderTo
+import com.rsicarelli.fakt.codegen.renderer.renderToString
 import com.rsicarelli.fakt.compiler.api.SourceSetContext
 import com.rsicarelli.fakt.compiler.core.context.ImportResolver
 import com.rsicarelli.fakt.compiler.core.telemetry.FaktLogger
@@ -27,14 +29,16 @@ internal data class CodeGenerators(
 /**
  * Contains all generated code pieces for a fake implementation.
  *
- * @property implementation The generated implementation class code (includes call history components)
- * @property factory The generated factory function code
- * @property configDsl The generated configuration DSL code
+ * Uses CodeFile for type-safe, composable code generation throughout the pipeline.
+ *
+ * @property implementation The generated implementation class (includes call history components)
+ * @property factory The generated factory function
+ * @property configDsl The generated configuration DSL class
  */
 internal data class GeneratedCode(
-    val implementation: String,
-    val factory: String,
-    val configDsl: String,
+    val implementation: CodeFile,
+    val factory: CodeFile,
+    val configDsl: CodeFile,
 ) {
     /**
      * Calculates total lines of code across all generated components.
@@ -42,7 +46,14 @@ internal data class GeneratedCode(
      * @return Total non-blank, non-comment lines of code
      */
     fun calculateTotalLOC(): Int {
-        val combinedCode = "$implementation\n$factory\n$configDsl"
+        val combinedCode =
+            buildString {
+                append(implementation.renderToString())
+                appendLine()
+                append(factory.renderToString())
+                appendLine()
+                append(configDsl.renderToString())
+            }
         return calculateLOC(combinedCode)
     }
 }
@@ -78,18 +89,6 @@ internal class CodeGenerator(
     private companion object {
         /** Length of "Main" suffix for source set name transformation. */
         private const val MAIN_SUFFIX_LENGTH = 4
-
-        /** Base overhead for generated code (package, imports, class header). */
-        const val CODE_SIZE_BASE_OVERHEAD = 500
-
-        /** Estimated characters per method (call tracking + behavior + override + config). */
-        const val CODE_SIZE_PER_METHOD = 200
-
-        /** Estimated characters per property (call tracking + behavior + override + config). */
-        const val CODE_SIZE_PER_PROPERTY = 100
-
-        /** Estimated characters per import statement. */
-        const val CODE_SIZE_PER_IMPORT = 30
     }
 
     /**
@@ -149,7 +148,7 @@ internal class CodeGenerator(
             // Collect required imports for implementation
             val requiredImports = importResolver.collectRequiredImports(analysis, packageName)
 
-            // Generate implementation + factory
+            // Generate implementation + factory using DSL
             val generated =
                 generators.implementation.generateImplementation(
                     analysis,
@@ -157,24 +156,13 @@ internal class CodeGenerator(
                     requiredImports.toList(),
                 )
 
-            // Render CodeFile to string with capacity estimation for performance
-            val estimatedCapacity =
-                estimateCodeSize(
-                    methodCount = analysis.functions.size,
-                    propertyCount = analysis.properties.size,
-                    importCount = requiredImports.size,
-                )
-            val builder = CodeBuilder(builder = StringBuilder(estimatedCapacity))
-            generated.implementationFile.renderTo(builder)
-            val implementationCode = builder.build()
-
-            // Assemble final code
+            // Assemble final code using CodeFile throughout
             val generatedCode =
                 GeneratedCode(
-                    implementation = implementationCode, // Complete file with package + imports + call history
+                    implementation = generated.implementationFile,
                     factory = generated.factoryFunction,
                     configDsl =
-                        generators.configDsl.generateConfigurationDsl(
+                        generators.configDsl.generateConfigurationDslCodeFile(
                             analysis,
                             fakeClassName,
                         ),
@@ -222,7 +210,7 @@ internal class CodeGenerator(
             val requiredImports =
                 importResolver.collectRequiredImportsForClass(analysis, packageName)
 
-            // Generate implementation + factory
+            // Generate implementation + factory using DSL
             val generated =
                 generators.implementation.generateClassFake(
                     analysis,
@@ -230,26 +218,13 @@ internal class CodeGenerator(
                     requiredImports.toList(),
                 )
 
-            // Render CodeFile to string with capacity estimation for performance
-            val totalMethods = analysis.abstractMethods.size + analysis.openMethods.size
-            val totalProperties = analysis.abstractProperties.size + analysis.openProperties.size
-            val estimatedCapacity =
-                estimateCodeSize(
-                    methodCount = totalMethods,
-                    propertyCount = totalProperties,
-                    importCount = requiredImports.size,
-                )
-            val builder = CodeBuilder(builder = StringBuilder(estimatedCapacity))
-            generated.implementationFile.renderTo(builder)
-            val implementationCode = builder.build()
-
-            // Assemble final code
+            // Assemble final code using CodeFile throughout
             val generatedCode =
                 GeneratedCode(
-                    implementation = implementationCode, // Complete file with package + imports + call history
+                    implementation = generated.implementationFile,
                     factory = generated.factoryFunction,
                     configDsl =
-                        generators.configDsl.generateConfigurationDsl(
+                        generators.configDsl.generateConfigurationDslCodeFile(
                             analysis,
                             fakeClassName,
                         ),
@@ -302,27 +277,41 @@ internal class CodeGenerator(
         packageDir.mkdirs()
         val outputFile = packageDir.resolve("$fakeClassName.kt")
 
-        // Implementation includes package, imports, class, and call history components via DSL
-        // Factory and configDSL are still old generators (no package/imports)
-        val fullCode =
-            buildString {
-                // Implementation already has: package, imports, class, call history (from DSL)
-                append(code.implementation)
-                appendLine()
-
-                // Add factory function (no package/imports)
-                append(code.factory)
-                appendLine()
-                appendLine() // Blank line before config class
-
-                // Add configuration DSL (no package/imports)
-                append(code.configDsl)
-            }
+        // Render all CodeFiles to a single output string
+        val fullCode = renderGeneratedCode(code)
 
         // Use buffered writer for better I/O performance
         outputFile.bufferedWriter().use { writer ->
             writer.write(fullCode)
         }
+    }
+
+    /**
+     * Renders GeneratedCode (all CodeFile parts) to a single string.
+     *
+     * The implementation CodeFile has package + imports + class + call history.
+     * Factory and configDsl CodeFiles have empty package, so we extract just their declarations.
+     */
+    private fun renderGeneratedCode(code: GeneratedCode): String {
+        val builder = CodeBuilder()
+
+        // Render implementation (has package, imports, class, call history)
+        code.implementation.renderTo(builder)
+        builder.appendLine()
+
+        // Render factory function declarations only (no package/imports)
+        code.factory.declarations.forEach { declaration ->
+            declaration.renderTo(builder)
+        }
+        builder.appendLine()
+        builder.appendLine() // Blank line before config class
+
+        // Render config DSL declarations only (no package/imports)
+        code.configDsl.declarations.forEach { declaration ->
+            declaration.renderTo(builder)
+        }
+
+        return builder.build()
     }
 
     /**
@@ -354,53 +343,12 @@ internal class CodeGenerator(
         packageDir.mkdirs()
         val outputFile = packageDir.resolve("$fakeClassName.kt")
 
-        // Implementation includes package, imports, class, and call history components via DSL
-        // Factory and configDSL are still old generators (no package/imports)
-        val fullCode =
-            buildString {
-                // Implementation already has: package, imports, class, call history (from DSL)
-                append(code.implementation)
-                appendLine()
-
-                // Add factory function (no package/imports)
-                append(code.factory)
-                appendLine()
-                appendLine() // Blank line before config class
-
-                // Add configuration DSL (no package/imports)
-                append(code.configDsl)
-            }
+        // Render all CodeFiles to a single output string
+        val fullCode = renderGeneratedCode(code)
 
         // Use buffered writer for better I/O performance
         outputFile.bufferedWriter().use { writer ->
             writer.write(fullCode)
         }
     }
-
-    /**
-     * Estimates the size of generated code for StringBuilder capacity hint.
-     *
-     * This avoids StringBuilder reallocation during code generation,
-     * improving performance by 2-3%.
-     *
-     * Heuristic based on typical fake structure:
-     * - Base overhead: 500 chars (package, imports, class header)
-     * - Per method: ~200 chars (call tracking + behavior property + override + config)
-     * - Per property: ~100 chars (call tracking + behavior + override + config)
-     * - Per import: ~30 chars average
-     *
-     * @param methodCount Number of methods in the interface
-     * @param propertyCount Number of properties in the interface
-     * @param importCount Number of import statements
-     * @return Estimated capacity in characters
-     */
-    private fun estimateCodeSize(
-        methodCount: Int,
-        propertyCount: Int,
-        importCount: Int,
-    ): Int =
-        CODE_SIZE_BASE_OVERHEAD +
-            (methodCount * CODE_SIZE_PER_METHOD) +
-            (propertyCount * CODE_SIZE_PER_PROPERTY) +
-            (importCount * CODE_SIZE_PER_IMPORT)
 }

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/ir/generation/ConfigurationDslGenerator.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/ir/generation/ConfigurationDslGenerator.kt
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.rsicarelli.fakt.compiler.ir.generation
 
+import com.rsicarelli.fakt.codegen.builder.ClassBuilder
+import com.rsicarelli.fakt.codegen.builder.codeFile
+import com.rsicarelli.fakt.codegen.model.CodeClass
+import com.rsicarelli.fakt.codegen.model.CodeFile
+import com.rsicarelli.fakt.codegen.renderer.CodeBuilder
+import com.rsicarelli.fakt.codegen.renderer.renderTo
 import com.rsicarelli.fakt.compiler.core.types.TypeResolution
 import com.rsicarelli.fakt.compiler.fir.metadata.FirVisibility
-import com.rsicarelli.fakt.compiler.fir.metadata.toModifier
 import com.rsicarelli.fakt.compiler.ir.analysis.AnnotationAnalysis
 import com.rsicarelli.fakt.compiler.ir.analysis.ClassAnalysis
 import com.rsicarelli.fakt.compiler.ir.analysis.FunctionAnalysis
@@ -15,6 +20,8 @@ import com.rsicarelli.fakt.compiler.ir.analysis.PropertyAnalysis
 /**
  * Generates configuration DSL classes for fake implementations.
  * Creates type-safe DSL classes that provide convenient configuration of fake behavior.
+ *
+ * Uses the type-safe CodeFile DSL for clean, composable code generation.
  */
 internal class ConfigurationDslGenerator(
     private val typeResolver: TypeResolution,
@@ -27,7 +34,66 @@ internal class ConfigurationDslGenerator(
     }
 
     /**
+     * Generates a configuration DSL CodeFile for the fake implementation.
+     *
+     * Uses type-safe DSL for clean, composable code generation.
+     * The returned CodeFile contains only the class declaration (no package/imports),
+     * suitable for being added to an existing file.
+     *
+     * @param analysis The analyzed interface metadata
+     * @param fakeClassName The name of the fake implementation class
+     * @return CodeFile containing the configuration DSL class
+     */
+    fun generateConfigurationDslCodeFile(
+        analysis: InterfaceAnalysis,
+        fakeClassName: String,
+    ): CodeFile {
+        val configClassName = "Fake${analysis.interfaceName}Config"
+        val (typeParamsForHeader, whereClause) = formatTypeParametersWithWhereClause(analysis.typeParameters)
+        val typeArguments = extractTypeParameterNames(analysis.typeParameters)
+        val propagatedAnnotations = extractPropagatedAnnotations(analysis.annotations)
+
+        return codeFile("") {
+            klass(configClassName) {
+                // Apply visibility
+                applyVisibility(analysis.visibility)
+
+                // Add type parameters
+                addTypeParameters(typeParamsForHeader)
+
+                // Add where clause if needed
+                if (whereClause.isNotEmpty()) {
+                    where(whereClause)
+                }
+
+                // Add constructor property for fake reference
+                constructorProperty("fake", "$fakeClassName$typeArguments") {
+                    private()
+                }
+
+                // Add propagated annotations
+                propagatedAnnotations.forEach { annotation ->
+                    annotation(annotation.simpleName, annotation.renderedArguments)
+                }
+
+                // Generate function configurators
+                analysis.functions.forEach { func ->
+                    generateFunctionConfigurator(func, analysis.visibility)
+                }
+
+                // Generate property configurators
+                analysis.properties.forEach { prop ->
+                    generatePropertyConfigurator(prop, analysis.visibility)
+                }
+            }
+        }
+    }
+
+    /**
      * Generates a configuration DSL class for the fake implementation.
+     *
+     * This is the legacy string-based API that delegates to the DSL-based implementation
+     * and renders the result to a string.
      *
      * @param analysis The analyzed interface metadata
      * @param fakeClassName The name of the fake implementation class
@@ -37,53 +103,254 @@ internal class ConfigurationDslGenerator(
         analysis: InterfaceAnalysis,
         fakeClassName: String,
     ): String {
-        val (typeParamsForHeader, whereClause) = formatTypeParametersWithWhereClause(analysis.typeParameters)
+        val codeFile = generateConfigurationDslCodeFile(analysis, fakeClassName)
 
-        // Extract annotations that need to be propagated to the config class
-        val propagatedAnnotations = extractPropagatedAnnotations(analysis.annotations)
+        // Extract the class declaration and render it
+        val klass =
+            codeFile.declarations.firstOrNull() as? CodeClass
+                ?: return ""
 
-        val headerConfig =
-            ClassHeaderConfig(
-                configClassName = "Fake${analysis.interfaceName}Config",
-                typeParameters = formatTypeParameters(typeParamsForHeader),
-                fakeClassName = fakeClassName,
-                typeParameterNames = extractTypeParameterNames(analysis.typeParameters),
-                whereClause = whereClause,
-                visibility = analysis.visibility,
-                propagatedAnnotations = propagatedAnnotations,
-            )
-
-        return buildString {
-            appendLine(generateClassHeader(headerConfig))
-            append(generateFunctionConfigurators(analysis.functions, analysis.visibility))
-            append(generatePropertyConfigurators(analysis.properties, analysis.visibility))
-        }.trimEnd() + "\n}"
+        val builder = CodeBuilder()
+        klass.renderTo(builder)
+        return builder.build().trimEnd()
     }
 
-    private fun generateClassHeader(config: ClassHeaderConfig): String =
-        buildString {
-            // Add propagated annotations (@OptIn, @Deprecated)
-            // Note: We don't add @OptIn for opt-in markers here because:
-            // 1. The impl class already has @OptIn(MarkerClass::class)
-            // 2. Config class just references the impl, doesn't need its own @OptIn
-            config.propagatedAnnotations.forEach { annotation ->
-                appendLine(renderAnnotation(annotation))
-            }
+    /**
+     * Generates a configuration DSL CodeFile for the fake class implementation.
+     *
+     * @param analysis The analyzed class metadata
+     * @param fakeClassName The name of the fake implementation class
+     * @return CodeFile containing the configuration DSL class
+     */
+    fun generateConfigurationDslCodeFile(
+        analysis: ClassAnalysis,
+        fakeClassName: String,
+    ): CodeFile {
+        val configClassName = "Fake${analysis.className}Config"
+        val (typeParamsForHeader, whereClause) = formatTypeParametersWithWhereClause(analysis.typeParameters)
+        val typeArguments = extractTypeParameterNames(analysis.typeParameters)
+        val propagatedAnnotations = extractPropagatedAnnotations(analysis.annotations)
 
-            val visibilityModifier = config.visibility.toModifier()
-            if (config.whereClause.isNotEmpty()) {
-                append(
-                    "${visibilityModifier}class ${config.configClassName}${config.typeParameters}(" +
-                        "private val fake: ${config.fakeClassName}${config.typeParameterNames}) " +
-                        "where ${config.whereClause} {",
-                )
-            } else {
-                append(
-                    "${visibilityModifier}class ${config.configClassName}${config.typeParameters}(" +
-                        "private val fake: ${config.fakeClassName}${config.typeParameterNames}) {",
-                )
+        return codeFile("") {
+            klass(configClassName) {
+                // Apply visibility
+                applyVisibility(analysis.visibility)
+
+                // Add type parameters
+                addTypeParameters(typeParamsForHeader)
+
+                // Add where clause if needed
+                if (whereClause.isNotEmpty()) {
+                    where(whereClause)
+                }
+
+                // Add constructor property for fake reference
+                constructorProperty("fake", "$fakeClassName$typeArguments") {
+                    private()
+                }
+
+                // Add propagated annotations
+                propagatedAnnotations.forEach { annotation ->
+                    annotation(annotation.simpleName, annotation.renderedArguments)
+                }
+
+                // Generate configuration methods for abstract methods
+                analysis.abstractMethods.forEach { func ->
+                    generateFunctionConfigurator(func, analysis.visibility)
+                }
+
+                // Generate configuration methods for open methods
+                analysis.openMethods.forEach { func ->
+                    generateFunctionConfigurator(func, analysis.visibility)
+                }
+
+                // Generate configuration methods for abstract properties
+                analysis.abstractProperties.forEach { prop ->
+                    generatePropertyConfigurator(prop, analysis.visibility)
+                }
+
+                // Generate configuration methods for open properties
+                analysis.openProperties.forEach { prop ->
+                    generatePropertyConfigurator(prop, analysis.visibility)
+                }
             }
         }
+    }
+
+    /**
+     * Generates a configuration DSL class for the fake class implementation.
+     *
+     * This is the legacy string-based API that delegates to the DSL-based implementation.
+     *
+     * @param analysis The analyzed class metadata
+     * @param fakeClassName The name of the fake implementation class
+     * @return The generated configuration DSL class code
+     */
+    fun generateConfigurationDsl(
+        analysis: ClassAnalysis,
+        fakeClassName: String,
+    ): String {
+        val codeFile = generateConfigurationDslCodeFile(analysis, fakeClassName)
+
+        // Extract the class declaration and render it
+        val klass =
+            codeFile.declarations.firstOrNull() as? CodeClass
+                ?: return ""
+
+        val builder = CodeBuilder()
+        klass.renderTo(builder)
+        return builder.build().trimEnd()
+    }
+
+    /**
+     * Applies visibility modifier to the class builder.
+     */
+    private fun ClassBuilder.applyVisibility(visibility: FirVisibility) {
+        when (visibility) {
+            FirVisibility.PUBLIC -> public()
+            FirVisibility.INTERNAL -> internal()
+            else -> public()
+        }
+    }
+
+    /**
+     * Adds type parameters to the class builder.
+     */
+    private fun ClassBuilder.addTypeParameters(typeParamsForHeader: List<String>) {
+        typeParamsForHeader.forEach { param ->
+            val parts = param.split(" : ", limit = 2)
+            val name = parts[0].trim()
+            val constraint = if (parts.size > 1) parts[1].trim() else null
+            if (constraint != null) {
+                typeParam(name, constraint)
+            } else {
+                typeParam(name)
+            }
+        }
+    }
+
+    /**
+     * Generates a function configurator method.
+     */
+    private fun ClassBuilder.generateFunctionConfigurator(
+        function: FunctionAnalysis,
+        visibility: FirVisibility,
+    ) {
+        val functionName = function.name
+        val capitalizedName = functionName.replaceFirstChar { it.uppercase() }
+
+        // Build behavior signature
+        val behaviorSignature = buildBehaviorSignature(function)
+
+        function(functionName) {
+            // Apply visibility
+            when (visibility) {
+                FirVisibility.PUBLIC -> public()
+                FirVisibility.INTERNAL -> internal()
+                else -> public()
+            }
+
+            // Add type parameters if present
+            function.typeParameters.forEach { tp ->
+                val parts = tp.split(" : ", limit = 2)
+                val name = parts[0].trim()
+                val constraint = if (parts.size > 1) parts[1].trim() else null
+                if (constraint != null) {
+                    typeParam(name, constraint)
+                } else {
+                    typeParam(name)
+                }
+            }
+
+            parameter("behavior", behaviorSignature)
+            returns("Unit")
+            expressionBody = "fake.configure$capitalizedName(behavior)"
+        }
+    }
+
+    /**
+     * Generates a property configurator method.
+     */
+    private fun ClassBuilder.generatePropertyConfigurator(
+        property: PropertyAnalysis,
+        visibility: FirVisibility,
+    ) {
+        val propertyName = property.name
+        val capitalizedName = propertyName.replaceFirstChar { it.uppercase() }
+        val propertyType = typeResolver.irTypeToKotlinString(property.type, preserveTypeParameters = true)
+
+        // Getter configuration
+        function(propertyName) {
+            when (visibility) {
+                FirVisibility.PUBLIC -> public()
+                FirVisibility.INTERNAL -> internal()
+                else -> public()
+            }
+
+            parameter("behavior", "() -> $propertyType")
+            returns("Unit")
+            expressionBody = "fake.configure$capitalizedName(behavior)"
+        }
+
+        // Setter configuration for mutable properties
+        if (property.isMutable) {
+            function("set$capitalizedName") {
+                when (visibility) {
+                    FirVisibility.PUBLIC -> public()
+                    FirVisibility.INTERNAL -> internal()
+                    else -> public()
+                }
+
+                parameter("behavior", "($propertyType) -> Unit")
+                returns("Unit")
+                expressionBody = "fake.configureSet$capitalizedName(behavior)"
+            }
+        }
+    }
+
+    /**
+     * Builds the behavior signature for a function.
+     */
+    private fun buildBehaviorSignature(function: FunctionAnalysis): String {
+        val suspendModifier = if (function.isSuspend) "suspend " else ""
+
+        // Keep original parameter types (including method-level generics)
+        val regularParamTypes =
+            function.parameters.joinToString(", ") { param ->
+                if (param.isVararg) {
+                    val elementType = unwrapVarargsType(param)
+                    "Array<out $elementType>"
+                } else {
+                    typeResolver.irTypeToKotlinString(param.type, preserveTypeParameters = true)
+                }
+            }
+
+        // For extension functions, prepend receiver type to parameter list
+        val parameterTypes =
+            if (function.extensionReceiverType != null) {
+                val receiverTypeStr =
+                    typeResolver.irTypeToKotlinString(
+                        function.extensionReceiverType,
+                        preserveTypeParameters = true,
+                    )
+                if (regularParamTypes.isEmpty()) {
+                    receiverTypeStr
+                } else {
+                    "$receiverTypeStr, $regularParamTypes"
+                }
+            } else {
+                regularParamTypes
+            }
+
+        // Keep original return type (including method-level generics)
+        val returnType = typeResolver.irTypeToKotlinString(function.returnType, preserveTypeParameters = true)
+
+        return if (parameterTypes.isEmpty()) {
+            "$suspendModifier() -> $returnType"
+        } else {
+            "$suspendModifier($parameterTypes) -> $returnType"
+        }
+    }
 
     /**
      * Extracts annotations that need to be propagated to the config class.
@@ -98,131 +365,6 @@ internal class ConfigurationDslGenerator(
         annotations.filter {
             (it.simpleName == "OptIn" || it.simpleName == "Deprecated") && !it.isOptInMarker
         }
-
-    /**
-     * Renders an annotation to its string representation.
-     */
-    private fun renderAnnotation(annotation: AnnotationAnalysis): String =
-        if (annotation.renderedArguments.isEmpty()) {
-            "@${annotation.simpleName}"
-        } else {
-            "@${annotation.simpleName}(${annotation.renderedArguments.joinToString(", ")})"
-        }
-
-    private fun generateFunctionConfigurators(
-        functions: List<FunctionAnalysis>,
-        visibility: FirVisibility,
-    ): String {
-        val visibilityModifier = visibility.toModifier()
-        return functions.joinToString("") { function ->
-            // Preserve full generic signatures (no erasure)
-            val hasMethodGenerics = function.typeParameters.isNotEmpty()
-
-            val methodTypeParams =
-                if (hasMethodGenerics) {
-                    "<${function.typeParameters.joinToString(", ")}> "
-                } else {
-                    ""
-                }
-
-            // Keep original parameter types (including method-level generics)
-            val regularParamTypes =
-                if (function.parameters.isEmpty()) {
-                    ""
-                } else {
-                    function.parameters.joinToString(", ") { param ->
-                        if (param.isVararg) {
-                            val elementType = unwrapVarargsType(param)
-                            "Array<out $elementType>"
-                        } else {
-                            // Keep full signature - no erasure!
-                            typeResolver.irTypeToKotlinString(
-                                param.type,
-                                preserveTypeParameters = true,
-                            )
-                        }
-                    }
-                }
-
-            // For extension functions, prepend receiver type to parameter list
-            val parameterTypes =
-                if (function.extensionReceiverType != null) {
-                    val receiverTypeStr =
-                        typeResolver.irTypeToKotlinString(
-                            function.extensionReceiverType,
-                            preserveTypeParameters = true,
-                        )
-                    if (regularParamTypes.isEmpty()) {
-                        receiverTypeStr
-                    } else {
-                        "$receiverTypeStr, $regularParamTypes"
-                    }
-                } else {
-                    regularParamTypes
-                }
-
-            // Keep original return type (including method-level generics)
-            val returnType =
-                typeResolver.irTypeToKotlinString(
-                    function.returnType,
-                    preserveTypeParameters = true,
-                )
-
-            val suspendModifier = if (function.isSuspend) "suspend " else ""
-
-            "    ${visibilityModifier}fun $methodTypeParams${function.name}(" +
-                "behavior: $suspendModifier($parameterTypes) -> $returnType): Unit " +
-                "= fake.configure${function.name.capitalize()}(behavior)\n\n"
-        }
-    }
-
-    private fun generatePropertyConfigurators(
-        properties: List<PropertyAnalysis>,
-        visibility: FirVisibility,
-    ): String {
-        val visibilityModifier = visibility.toModifier()
-        return properties.joinToString("") { property ->
-            val propertyType =
-                typeResolver.irTypeToKotlinString(property.type, preserveTypeParameters = true)
-
-            buildString {
-                append(
-                    "    ${visibilityModifier}fun ${property.name}(behavior: () -> $propertyType): Unit " +
-                        "= fake.configure${property.name.capitalize()}(behavior)\n",
-                )
-
-                // For mutable properties, add setter configuration
-                if (property.isMutable) {
-                    val capitalizedName = property.name.capitalize()
-                    append("    ${visibilityModifier}fun set$capitalizedName")
-                    append("(behavior: ($propertyType) -> Unit): Unit")
-                    append(" = fake.configureSet$capitalizedName(behavior)\n")
-                }
-
-                // Add blank line between property configurations
-                append("\n")
-            }
-        }
-    }
-
-    private fun formatTypeParameters(typeParamsForHeader: List<String>): String =
-        if (typeParamsForHeader.isNotEmpty()) {
-            "<${typeParamsForHeader.joinToString(", ")}>"
-        } else {
-            ""
-        }
-
-    private fun extractTypeParameterNames(typeParameters: List<String>): String =
-        if (typeParameters.isNotEmpty()) {
-            "<${typeParameters.joinToString(", ") { it.substringBefore(" :").trim() }}>"
-        } else {
-            ""
-        }
-
-    /**
-     * Capitalize first letter of string.
-     */
-    private fun String.capitalize(): String = replaceFirstChar { it.uppercase() }
 
     /**
      * Unwraps varargs Array<T> to element type T.
@@ -275,190 +417,12 @@ internal class ConfigurationDslGenerator(
     }
 
     /**
-     * Generates a configuration DSL class for the fake class implementation.
-     *
-     * @param analysis The analyzed class metadata
-     * @param fakeClassName The name of the fake implementation class
-     * @return The generated configuration DSL class code
+     * Extracts type parameter names as a type argument string.
      */
-    fun generateConfigurationDsl(
-        analysis: ClassAnalysis,
-        fakeClassName: String,
-    ): String {
-        val (typeParamsForHeader, whereClause) = formatTypeParametersWithWhereClause(analysis.typeParameters)
-
-        val typeParameters =
-            if (typeParamsForHeader.isNotEmpty()) {
-                "<${typeParamsForHeader.joinToString(", ")}>"
-            } else {
-                ""
-            }
-
-        val typeParameterNames =
-            if (analysis.typeParameters.isNotEmpty()) {
-                analysis.typeParameters.map { it.substringBefore(" :").trim() }
-            } else {
-                emptyList()
-            }
-
-        val typeArguments =
-            if (typeParameterNames.isNotEmpty()) {
-                "<${typeParameterNames.joinToString(", ")}>"
-            } else {
-                ""
-            }
-
-        // Extract annotations that need to be propagated to the config class
-        val propagatedAnnotations = extractPropagatedAnnotations(analysis.annotations)
-
-        val headerConfig =
-            ClassHeaderConfig(
-                configClassName = "Fake${analysis.className}Config",
-                typeParameters = typeParameters,
-                fakeClassName = fakeClassName,
-                typeParameterNames = typeArguments,
-                whereClause = whereClause,
-                visibility = analysis.visibility,
-                propagatedAnnotations = propagatedAnnotations,
-            )
-
-        return buildString {
-            appendLine(generateClassHeader(headerConfig))
-
-            // Generate configuration methods for abstract methods
-            for (function in analysis.abstractMethods) {
-                appendLine(generateConfigMethodForFunction(function, analysis.visibility))
-            }
-
-            // Generate configuration methods for open methods
-            for (function in analysis.openMethods) {
-                appendLine(generateConfigMethodForFunction(function, analysis.visibility))
-            }
-
-            // Generate configuration methods for abstract properties
-            for (property in analysis.abstractProperties) {
-                appendLine(generateConfigMethodForProperty(property, analysis.visibility))
-            }
-
-            // Generate configuration methods for open properties
-            for (property in analysis.openProperties) {
-                appendLine(generateConfigMethodForProperty(property, analysis.visibility))
-            }
-
-            appendLine("}")
+    private fun extractTypeParameterNames(typeParameters: List<String>): String =
+        if (typeParameters.isNotEmpty()) {
+            "<${typeParameters.joinToString(", ") { it.substringBefore(" :").trim() }}>"
+        } else {
+            ""
         }
-    }
-
-    /**
-     * Generates a single configuration method for a property (abstract or open).
-     * Used for class DSL generation.
-     */
-    private fun generateConfigMethodForProperty(
-        property: PropertyAnalysis,
-        visibility: FirVisibility,
-    ): String {
-        val propertyName = property.name
-        val returnTypeString =
-            typeResolver.irTypeToKotlinString(property.type, preserveTypeParameters = true)
-        val capitalizedName = propertyName.replaceFirstChar { it.titlecase() }
-        val visibilityModifier = visibility.toModifier()
-
-        return buildString {
-            // Getter configuration
-            appendLine(
-                "    ${visibilityModifier}fun $propertyName(behavior: () -> $returnTypeString): Unit " +
-                    "= fake.configure$capitalizedName(behavior)",
-            )
-
-            // Setter configuration for mutable properties
-            if (property.isMutable) {
-                appendLine(
-                    "    ${visibilityModifier}fun set$capitalizedName(behavior: ($returnTypeString) -> Unit): Unit " +
-                        "= fake.configureSet$capitalizedName(behavior)",
-                )
-            }
-        }.trimEnd() // Remove trailing newline so caller can control formatting
-    }
-
-    /**
-     * Generates a single configuration method for a function (abstract or open).
-     * Shared logic between interface and class DSL generation.
-     *
-     * Preserves full generic signatures (no erasure) for type-safe DSL.
-     */
-    private fun generateConfigMethodForFunction(
-        function: FunctionAnalysis,
-        visibility: FirVisibility,
-    ): String {
-        val functionName = function.name
-        val suspendModifier = if (function.isSuspend) "suspend " else ""
-        val visibilityModifier = visibility.toModifier()
-
-        // Preserve full generic signatures (no erasure)
-        val hasMethodGenerics = function.typeParameters.isNotEmpty()
-
-        val methodTypeParams =
-            if (hasMethodGenerics) {
-                "<${function.typeParameters.joinToString(", ")}> "
-            } else {
-                ""
-            }
-
-        // Keep original parameter types (including method-level generics)
-        val regularParamTypes =
-            function.parameters.joinToString(", ") { param ->
-                if (param.isVararg) {
-                    val elementType = unwrapVarargsType(param)
-                    "Array<out $elementType>"
-                } else {
-                    // Keep full signature - no erasure!
-                    typeResolver.irTypeToKotlinString(param.type, preserveTypeParameters = true)
-                }
-            }
-
-        // For extension functions, prepend receiver type to parameter list
-        val parameterTypes =
-            if (function.extensionReceiverType != null) {
-                val receiverTypeStr =
-                    typeResolver.irTypeToKotlinString(
-                        function.extensionReceiverType,
-                        preserveTypeParameters = true,
-                    )
-                if (regularParamTypes.isEmpty()) {
-                    receiverTypeStr
-                } else {
-                    "$receiverTypeStr, $regularParamTypes"
-                }
-            } else {
-                regularParamTypes
-            }
-
-        // Keep original return type (including method-level generics)
-        val returnType =
-            typeResolver.irTypeToKotlinString(function.returnType, preserveTypeParameters = true)
-
-        // Build behavior signature with full generic types
-        val behaviorSignature =
-            if (parameterTypes.isEmpty()) {
-                "$suspendModifier() -> $returnType"
-            } else {
-                "$suspendModifier($parameterTypes) -> $returnType"
-            }
-
-        return "    ${visibilityModifier}fun $methodTypeParams$functionName(behavior: $behaviorSignature): Unit " +
-            "= fake.configure${functionName.replaceFirstChar { it.uppercase() }}(behavior)"
-    }
 }
-
-/**
- * Configuration for generating a DSL class header.
- */
-private data class ClassHeaderConfig(
-    val configClassName: String,
-    val typeParameters: String,
-    val fakeClassName: String,
-    val typeParameterNames: String,
-    val whereClause: String,
-    val visibility: FirVisibility,
-    val propagatedAnnotations: List<AnnotationAnalysis> = emptyList(),
-)

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/ir/generation/ImplementationGenerator.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/ir/generation/ImplementationGenerator.kt
@@ -8,10 +8,9 @@ import com.rsicarelli.fakt.codegen.extensions.MethodSpec
 import com.rsicarelli.fakt.codegen.extensions.PropertySpec
 import com.rsicarelli.fakt.codegen.extensions.generateCallHistoryDeclarations
 import com.rsicarelli.fakt.codegen.extensions.generateCompleteFake
-import com.rsicarelli.fakt.codegen.extensions.generateFactoryFunction
+import com.rsicarelli.fakt.codegen.extensions.generateFactoryFunctionCodeFile
 import com.rsicarelli.fakt.codegen.model.CodeFile
 import com.rsicarelli.fakt.compiler.core.types.TypeResolution
-import com.rsicarelli.fakt.compiler.fir.metadata.FirVisibility
 import com.rsicarelli.fakt.compiler.ir.analysis.AnnotationAnalysis
 import com.rsicarelli.fakt.compiler.ir.analysis.ClassAnalysis
 import com.rsicarelli.fakt.compiler.ir.analysis.InterfaceAnalysis
@@ -19,12 +18,14 @@ import com.rsicarelli.fakt.compiler.ir.analysis.InterfaceAnalysis
 /**
  * Holds the generated code pieces from the implementation generator.
  *
+ * Uses CodeFile for type-safe, composable code generation.
+ *
  * @property implementationFile CodeFile with package, imports, implementation class, and call history components
- * @property factoryFunction Generated factory function code (string)
+ * @property factoryFunction CodeFile containing the factory function
  */
 internal data class GeneratedFakeCode(
     val implementationFile: CodeFile,
-    val factoryFunction: String,
+    val factoryFunction: CodeFile,
 )
 
 /**
@@ -38,12 +39,12 @@ internal class ImplementationGenerator(
     /**
      * Generates fake implementation and factory for an interface.
      *
-     * Returns implementation CodeFile and factory function string.
+     * Returns implementation and factory as CodeFiles for type-safe composition.
      *
      * @param analysis The analyzed interface metadata
      * @param packageName The package name for the generated code
      * @param imports Additional imports required by the interface (from ImportResolver)
-     * @return GeneratedFakeCode with CodeFile and factory string
+     * @return GeneratedFakeCode with CodeFiles for implementation and factory
      */
     fun generateImplementation(
         analysis: InterfaceAnalysis,
@@ -70,9 +71,9 @@ internal class ImplementationGenerator(
                 annotations = annotationSpecs,
             )
 
-        // Generate factory function with visibility for explicitApi() support
+        // Generate factory function CodeFile with visibility for explicitApi() support
         val factoryFunction =
-            generateFactoryFunction(
+            generateFactoryFunctionCodeFile(
                 FactoryFunctionSpec(
                     interfaceName = analysis.interfaceName,
                     typeParameters = analysis.typeParameters,
@@ -108,12 +109,12 @@ internal class ImplementationGenerator(
     /**
      * Generates fake implementation and factory for a class.
      *
-     * Returns implementation CodeFile and factory function string.
+     * Returns implementation and factory as CodeFiles for type-safe composition.
      *
      * @param analysis The analyzed class metadata
      * @param packageName The package name for the generated code
      * @param imports Additional imports required by the class (from ImportResolver)
-     * @return GeneratedFakeCode with CodeFile and factory string
+     * @return GeneratedFakeCode with CodeFiles for implementation and factory
      */
     fun generateClassFake(
         analysis: ClassAnalysis,
@@ -138,9 +139,9 @@ internal class ImplementationGenerator(
                 annotations = annotationSpecs,
             )
 
-        // Generate factory function with visibility for explicitApi() support
+        // Generate factory function CodeFile with visibility for explicitApi() support
         val factoryFunction =
-            generateFactoryFunction(
+            generateFactoryFunctionCodeFile(
                 FactoryFunctionSpec(
                     interfaceName = analysis.className,
                     typeParameters = analysis.typeParameters,


### PR DESCRIPTION
## Description

Migrate `FactoryExtensions.kt` and `ConfigurationDslGenerator.kt` from raw StringBuilder to the type-safe `codeFile {}` DSL, matching the pattern already used by `FakeGenerator.kt`.

**Key changes:**
- Add KDoc support to `CodeFunction` (kdoc property + rendering)
- Rewrite `generateFactoryFunctionCodeFile()` using DSL
- Rewrite `generateConfigurationDslCodeFile()` using DSL  
- Update `GeneratedCode` to use `CodeFile` for all components
- Add List-based `annotation()` overloads to avoid spread operator overhead
- Remove unused `estimateCodeSize` function

**Benefits:**
- Single consistent approach for all code generation
- Type-safe DSL catches errors at compile time
- Cleaner, more maintainable code

## Related Issue

N/A - Internal refactoring

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

### Files Modified

| File | Changes |
|------|---------|
| `CodeFile.kt` | Added `kdoc` to `CodeFunction` |
| `FunctionBuilder.kt` | Added `kdoc` property, List-based `annotation()` |
| `Rendering.kt` | Added KDoc rendering before functions |
| `FactoryExtensions.kt` | Rewritten with DSL |
| `ConfigurationDslGenerator.kt` | Rewritten with DSL |
| `CodeGenerator.kt` | Updated assembly, removed unused code |
| `ImplementationGenerator.kt` | Updated return types |
| `ClassBuilder.kt` | Added List-based `annotation()` |
| `DataClassBuilder.kt` | Added List-based `annotation()` |
| `PropertyBuilder.kt` | Added List-based `annotation()` |