### PR TITLE
docs: update documentation for call history and verification DSL

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -210,12 +210,12 @@ fun log(msg: String, level: LogLevel = INFO)
 
 ---
 
-## Call Tracking
+## Call Tracking & Verification
 
 <table>
 <tr><th>Case</th><th>Example</th></tr>
 <tr>
-<td><strong>StateFlow Counters</strong></td>
+<td><strong>Call Counts</strong></td>
 <td>
 
 ```kotlin
@@ -225,11 +225,25 @@ fake.trackCallCount // Thread-safe Int counter
 </td>
 </tr>
 <tr>
-<td><strong>Reactive Testing</strong></td>
+<td><strong>Verification DSL</strong></td>
 <td>
 
 ```kotlin
-fake.trackCallCount.test { awaitItem() shouldBe 1 } // Turbine
+fake.verifyTrack {
+    assertTrue(wasCalledTimes(2))
+    assertTrue(wasCalledWith("page_view"))
+}
+```
+
+</td>
+</tr>
+<tr>
+<td><strong>Call History</strong></td>
+<td>
+
+```kotlin
+assertEquals("page_view", fake.trackCallHistory.first.event)
+assertEquals(2, fake.trackCallHistory.all.size)
 ```
 
 </td>
@@ -249,7 +263,7 @@ fake.setThemeCallCount
 <td><strong>Thread Safety</strong></td>
 <td>
 
-All counters use `MutableStateFlow.update` for thread-safe operations.
+Call counts are derived from thread-safe internal state.
 
 </td>
 </tr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ val fake = fakeAnalytics {
 - **[Suspend Functions](user-guide/usage.md#suspend-functions)** - Working with coroutines and async code
 - **[Generics](user-guide/usage.md#generics)** - Generic interfaces and type parameters
 - **[Properties](user-guide/usage.md#properties)** - Faking val and var properties
-- **[Call Tracking](user-guide/usage.md#call-tracking)** - StateFlow-based reactive counters
+- **[Call Tracking](user-guide/usage.md#call-tracking-verification)** - Thread-safe call counting and verification DSL
 
 **Advanced Topics:**
 

--- a/docs/user-guide/generated-code-reference.md
+++ b/docs/user-guide/generated-code-reference.md
@@ -6,14 +6,17 @@ Generated code API and patterns.
 
 ## Generated Classes
 
-For each `@Fake` annotated interface, Fakt generates three components:
+For each `@Fake` annotated interface, Fakt generates several components:
 
 ### Implementation Class
 
 ```kotlin
 class Fake{Interface}Impl : {Interface} {
-    // StateFlow call counters
-    val {method}CallCount: StateFlow<Int>
+    // Call counters (derived from history)
+    val {method}CallCount: Int
+
+    // Call history
+    val {method}CallHistory: List<{Interface}{Method}Call>
 
     // Override interface members
     override fun {method}({params}): {return} = {method}Behavior({params})
@@ -41,15 +44,122 @@ class Fake{Interface}Config(private val fake: Fake{Interface}Impl) {
 
 ---
 
+## Call History Data Classes
+
+For each method with parameters, Fakt generates a data class capturing all arguments:
+
+```kotlin
+// For interface method: fun save(user: User, validate: Boolean): User
+data class FakeUserRepositorySaveCall(
+    val user: User,
+    val validate: Boolean
+)
+
+// For interface method: fun getUser(id: String): User?
+data class FakeUserRepositoryGetUserCall(
+    val id: String
+)
+```
+
+**Naming Pattern:** `Fake{Interface}{Method}Call`
+
+These data classes enable type-safe access to call history:
+
+```kotlin
+val fake = fakeUserRepository {
+    save { user, _ -> user }
+}
+
+fake.save(User("1", "Alice"), true)
+fake.save(User("2", "Bob"), false)
+
+// Access call history
+assertEquals(2, fake.saveCallHistory.size)
+assertEquals("Alice", fake.saveCallHistory[0].user.name)
+assertTrue(fake.saveCallHistory[0].validate)
+```
+
+---
+
+## Verifier Classes
+
+For each method, Fakt generates a verifier class with assertion helpers:
+
+```kotlin
+class Fake{Interface}{Method}Verifier(
+    private val history: List<Fake{Interface}{Method}Call>
+) {
+    // Assertion methods
+    fun wasCalledTimes(n: Int): Boolean
+    fun wasCalledWith({params}): Boolean
+    fun wasNeverCalled(): Boolean
+
+    // For single-parameter methods only:
+    fun wasCalledInOrder(vararg values: {ParamType}): Boolean
+    fun neverCalledWith(value: {ParamType}): Boolean
+
+    // History access
+    val first: Fake{Interface}{Method}Call
+    val lastOrNull: Fake{Interface}{Method}Call?
+    val all: List<Fake{Interface}{Method}Call>
+}
+```
+
+**Verifier API Reference:**
+
+| Method | Description |
+|--------|-------------|
+| `wasCalledTimes(n)` | Returns `true` if called exactly `n` times |
+| `wasCalledWith(...)` | Returns `true` if called with specified arguments |
+| `wasNeverCalled()` | Returns `true` if never called |
+| `wasCalledInOrder(...)` | Returns `true` if called in order (single-param only) |
+| `neverCalledWith(value)` | Returns `true` if never called with value (single-param only) |
+| `first` | First call data (throws `NoSuchElementException` if empty) |
+| `lastOrNull` | Last call data, or `null` if no calls |
+| `all` | Complete list of call data objects |
+
+---
+
+## Verify Extension Functions
+
+For each method, Fakt generates a scoped verification extension:
+
+```kotlin
+inline fun Fake{Interface}Impl.verify{Method}(
+    block: Fake{Interface}{Method}Verifier.() -> Unit
+)
+```
+
+**Usage:**
+
+```kotlin
+fake.verifySave {
+    assertTrue(wasCalledTimes(2))
+    assertTrue(wasCalledWith(User("1", "Alice"), true))
+    assertEquals("Alice", first.user.name)
+}
+
+fake.verifyTrack {
+    assertTrue(wasCalledInOrder("page_view", "button_click"))
+    assertTrue(neverCalledWith("error"))
+}
+```
+
+---
+
 ## Naming Conventions
 
-| Element                | Pattern                      | Example                  |
-|------------------------|------------------------------|--------------------------|
-| Implementation class   | `Fake{Interface}Impl`        | `FakeAnalyticsImpl`      |
-| Factory function       | `fake{Interface}`            | `fakeAnalytics`          |
-| Configuration DSL      | `Fake{Interface}Config`      | `FakeAnalyticsConfig`    |
-| Call counter           | `{method}CallCount`          | `trackCallCount`         |
-| Configuration method   | `{method}`                   | `track { }`              |
+| Element                | Pattern                           | Example                           |
+|------------------------|-----------------------------------|-----------------------------------|
+| Implementation class   | `Fake{Interface}Impl`             | `FakeAnalyticsImpl`               |
+| Factory function       | `fake{Interface}`                 | `fakeAnalytics`                   |
+| Configuration DSL      | `Fake{Interface}Config`           | `FakeAnalyticsConfig`             |
+| Call counter           | `{method}CallCount`               | `trackCallCount`                  |
+| Call history           | `{method}CallHistory`             | `trackCallHistory`                |
+| Call data class        | `Fake{Interface}{Method}Call`     | `FakeAnalyticsTrackCall`          |
+| Verifier class         | `Fake{Interface}{Method}Verifier` | `FakeAnalyticsTrackVerifier`      |
+| Verify function        | `verify{Method}`                  | `verifyTrack`                     |
+| Configuration method   | `{method}`                        | `track { }`                       |
 
 ---
 
@@ -62,6 +172,8 @@ com.example.services.Analytics (@Fake)
 → com.example.services.FakeAnalyticsImpl
 → com.example.services.fakeAnalytics()
 → com.example.services.FakeAnalyticsConfig
+→ com.example.services.FakeAnalyticsTrackCall
+→ com.example.services.FakeAnalyticsTrackVerifier
 ```
 
 ---

--- a/docs/user-guide/migration-from-mocks.md
+++ b/docs/user-guide/migration-from-mocks.md
@@ -241,6 +241,152 @@ fun `GIVEN generic repository WHEN saving item THEN returns success`() {
 
 ---
 
+## Verification Patterns
+
+Fakt's verification DSL provides expressive assertions comparable to mocking frameworks.
+
+### MockK verify → Fakt verify{Method}
+
+**MockK:**
+
+```kotlin
+@Test
+fun `verify specific arguments`() {
+    val mock = mockk<UserRepository>()
+    every { mock.save(any(), any()) } returns Unit
+
+    mock.save(User("1", "Alice"), true)
+    mock.save(User("2", "Bob"), false)
+
+    verify(exactly = 2) { mock.save(any(), any()) }
+    verify { mock.save(User("1", "Alice"), true) }
+}
+```
+
+**Fakt:**
+
+```kotlin
+@Test
+fun `verify specific arguments`() {
+    val fake = fakeUserRepository {
+        save { user, validate -> }
+    }
+
+    fake.save(User("1", "Alice"), true)
+    fake.save(User("2", "Bob"), false)
+
+    fake.verifySave {
+        assertTrue(wasCalledTimes(2))
+        assertTrue(wasCalledWith(User("1", "Alice"), true))
+    }
+}
+```
+
+### Mockito verify → Fakt verification
+
+**Mockito:**
+
+```kotlin
+@Test
+fun `verify call order and counts`() {
+    val mock = mock(Analytics::class.java)
+
+    mock.track("page_view")
+    mock.track("purchase")
+
+    verify(mock, times(2)).track(any())
+    verify(mock).track("page_view")
+    verify(mock, never()).track("error")
+}
+```
+
+**Fakt:**
+
+```kotlin
+@Test
+fun `verify call order and counts`() {
+    val fake = fakeAnalytics()
+
+    fake.track("page_view")
+    fake.track("purchase")
+
+    fake.verifyTrack {
+        assertTrue(wasCalledTimes(2))
+        assertTrue(wasCalledWith("page_view"))
+        assertTrue(neverCalledWith("error"))
+        assertTrue(wasCalledInOrder("page_view", "purchase"))
+    }
+}
+```
+
+### ArgumentCaptor → first, lastOrNull, all
+
+**MockK with slot:**
+
+```kotlin
+@Test
+fun `capture and inspect arguments`() {
+    val mock = mockk<UserRepository>()
+    val slot = slot<User>()
+    every { mock.save(capture(slot), any()) } returns Unit
+
+    mock.save(User("1", "Alice"), true)
+
+    assertEquals("Alice", slot.captured.name)
+}
+```
+
+**Mockito with ArgumentCaptor:**
+
+```kotlin
+@Test
+fun `capture and inspect arguments`() {
+    val mock = mock(UserRepository::class.java)
+    val captor = ArgumentCaptor.forClass(User::class.java)
+
+    mock.save(User("1", "Alice"), true)
+
+    verify(mock).save(captor.capture(), any())
+    assertEquals("Alice", captor.value.name)
+}
+```
+
+**Fakt with call history:**
+
+```kotlin
+@Test
+fun `capture and inspect arguments`() {
+    val fake = fakeUserRepository {
+        save { user, validate -> }
+    }
+
+    fake.save(User("1", "Alice"), true)
+    fake.save(User("2", "Bob"), false)
+
+    fake.verifySave {
+        // Access first call
+        assertEquals("Alice", first.user.name)
+        assertTrue(first.validate)
+
+        // Access last call
+        assertEquals("Bob", lastOrNull?.user?.name)
+
+        // Access all calls
+        assertEquals(2, all.size)
+        assertEquals(listOf("Alice", "Bob"), all.map { it.user.name })
+    }
+}
+```
+
+**Key differences:**
+
+- No need for separate captor/slot objects
+- Type-safe access to all parameters via generated data classes
+- `first`, `lastOrNull`, and `all` provide natural history access
+- Call history persists for the lifetime of the fake
+
+---
+
 ## Next Steps
 
 - **[Testing Patterns](testing-patterns.md)** - Best practices for fake-based testing

--- a/docs/user-guide/testing-patterns.md
+++ b/docs/user-guide/testing-patterns.md
@@ -123,24 +123,82 @@ fun `GIVEN repository failure WHEN saving user THEN handles error`() = runTest {
 
 ---
 
-## Use Turbine for Reactive Testing
+## Verification Patterns
 
-Test StateFlow call counters reactively:
+Use the verification DSL to assert on call history:
+
+### Basic Call Count Verification
 
 ```kotlin
 @Test
-fun `GIVEN fake WHEN calling repeatedly THEN emits counts`() = runTest {
+fun `GIVEN repository WHEN saving users THEN tracks call count`() {
+    val fake = fakeRepository {
+        saveUser { user -> Result.success(Unit) }
+    }
+
+    fake.saveUser(alice)
+    fake.saveUser(bob)
+
+    assertEquals(2, fake.saveUserCallCount)
+}
+```
+
+### Scoped Verification DSL
+
+```kotlin
+@Test
+fun `GIVEN repository WHEN saving users THEN verifies arguments`() {
+    val fake = fakeRepository {
+        saveUser { user -> Result.success(Unit) }
+    }
+
+    fake.saveUser(alice)
+    fake.saveUser(bob)
+
+    fake.verifySaveUser {
+        assertTrue(wasCalledTimes(2))
+        assertTrue(wasCalledWith(alice))
+        assertTrue(wasCalledWith(bob))
+        assertEquals("Alice", first.user.name)
+    }
+}
+```
+
+### Call Order Verification
+
+For single-parameter methods, verify call order:
+
+```kotlin
+@Test
+fun `GIVEN analytics WHEN tracking events THEN verifies order`() {
     val fake = fakeAnalytics()
 
-    fake.trackCallCount.test {
-        assertEquals(0, awaitItem())
+    fake.track("page_view")
+    fake.track("button_click")
+    fake.track("purchase")
 
-        fake.track("event1")
-        assertEquals(1, awaitItem())
-
-        fake.track("event2")
-        assertEquals(2, awaitItem())
+    fake.verifyTrack {
+        assertTrue(wasCalledInOrder("page_view", "button_click", "purchase"))
+        assertTrue(neverCalledWith("error"))
     }
+}
+```
+
+### Verifying No Calls
+
+```kotlin
+@Test
+fun `GIVEN cached data WHEN loading THEN does not call API`() {
+    val fake = fakeApiClient()
+    val service = CachedService(fake, preloadedCache)
+
+    service.getData("key")
+
+    fake.verifyFetchData {
+        assertTrue(wasNeverCalled())
+    }
+    // Or simply:
+    assertEquals(0, fake.fetchDataCallCount)
 }
 ```
 

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -639,9 +639,9 @@ interface Consumer<in T> {
 
 ---
 
-## Call Tracking
+## Call Tracking & Verification
 
-Every Fakt-generated fake includes automatic, thread-safe call tracking via Kotlin StateFlow.
+Every Fakt-generated fake includes automatic, thread-safe call tracking with a powerful verification DSL.
 
 ### Basic Call Tracking
 
@@ -676,25 +676,97 @@ fun `GIVEN fake logger WHEN logging messages THEN tracks call counts`() {
 
 ---
 
-### StateFlow Integration
+### Verification DSL
 
-Call counters are `StateFlow<Int>`, enabling reactive testing:
+Fakt generates a scoped verification DSL for each method, providing expressive assertions:
 
 ```kotlin
-import app.cash.turbine.test
+@Test
+fun `GIVEN repository WHEN saving users THEN verifies call history`() {
+    val fake = fakeUserRepository {
+        save { user -> user }
+    }
+
+    fake.save(User("1", "Alice"))
+    fake.save(User("2", "Bob"))
+
+    fake.verifySave {
+        assertTrue(wasCalledTimes(2))
+        assertTrue(wasCalledWith(User("1", "Alice")))
+        assertEquals("1", first.user.id)
+        assertEquals(2, all.size)
+    }
+}
+```
+
+**Verifier Methods:**
+
+| Method | Description |
+|--------|-------------|
+| `wasCalledTimes(n)` | Returns `true` if method was called exactly `n` times |
+| `wasCalledWith(...)` | Returns `true` if method was called with specified arguments |
+| `wasNeverCalled()` | Returns `true` if method was never called |
+| `wasCalledInOrder(...)` | Returns `true` if single-param method was called in specified order |
+| `neverCalledWith(...)` | Returns `true` if single-param method was never called with value |
+| `first` | First call's data (throws if no calls) |
+| `lastOrNull` | Last call's data, or `null` if no calls |
+| `all` | List of all call data objects |
+
+---
+
+### Call History Data Classes
+
+For each method, Fakt generates a data class capturing all parameters:
+
+```kotlin
+// For: fun save(user: User, validate: Boolean): User
+data class FakeUserRepositorySaveCall(
+    val user: User,
+    val validate: Boolean
+)
+
+// Access in verification:
+fake.verifySave {
+    assertEquals("Alice", first.user.name)
+    assertTrue(first.validate)
+    assertEquals(2, all.size)
+}
+```
+
+**Zero-Parameter Methods:**
+
+Methods without parameters still track call counts:
+
+```kotlin
+assertEquals(2, fake.clearCallCount)
+fake.verifyClear {
+    assertTrue(wasCalledTimes(2))
+}
+```
+
+---
+
+### Call Order Verification
+
+For methods with a single parameter, verify call order:
+
+```kotlin
+@Fake
+interface Analytics {
+    fun track(event: String)
+}
 
 @Test
-fun `GIVEN fake WHEN calling methods THEN counter updates reactively`() = runTest {
-    val fake = fakeRepository()
+fun `GIVEN analytics WHEN tracking events THEN verifies order`() {
+    val fake = fakeAnalytics()
 
-    fake.getUserCallCount.test {
-        assertEquals(0, awaitItem())
+    fake.track("page_view")
+    fake.track("button_click")
+    fake.track("purchase")
 
-        fake.getUser("123")
-        assertEquals(1, awaitItem())
-
-        fake.getUser("456")
-        assertEquals(2, awaitItem())
+    fake.verifyTrack {
+        assertTrue(wasCalledInOrder("page_view", "button_click", "purchase"))
+        assertTrue(neverCalledWith("error"))
     }
 }
 ```
@@ -726,7 +798,7 @@ assertEquals(1, fake.setThemeCallCount)
 
 ### Thread Safety
 
-All call counters are thread-safe via `MutableStateFlow.update`:
+Call counts are derived from thread-safe internal state. All tracking operations are safe for concurrent access:
 
 ```kotlin
 @Test


### PR DESCRIPTION
## Description

Updates documentation to reflect the new call history tracking (PR #34) and derive call count from history (PR #35) features:

- **Breaking API Change**: `methodCallCount` is now `Int` instead of `StateFlow<Int>` - usage changes from `fake.methodCallCount.value` to `fake.methodCallCount`
- **New Call History Data Classes**: `{Interface}{Method}Call` data classes capturing all parameters
- **New Verifier Classes**: Methods like `wasCalledTimes(n)`, `wasCalledWith(...)`, `wasNeverCalled()`, `wasCalledInOrder(...)`, `neverCalledWith()`
- **New Verification DSL**: `fake.verify{Method} { block }` for scoped verification

## Related Issue

Related to PR #34 and PR #35

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

### Files Updated

| File | Changes |
|------|---------|
| `docs/user-guide/usage.md` | Renamed "Call Tracking" to "Call Tracking & Verification", added Verification DSL section, removed Turbine examples |
| `docs/user-guide/generated-code-reference.md` | Changed `StateFlow<Int>` to `Int`, added Call History Data Classes, Verifier Classes, and Verify Extension Functions sections |
| `docs/get-started/features.md` | Updated Call Tracking table with new features |
| `docs/user-guide/testing-patterns.md` | Replaced Turbine section with Verification Patterns |
| `docs/index.md` | Updated link text and anchor |
| `docs/user-guide/migration-from-mocks.md` | Added comprehensive Verification Patterns section |

Verified with `mkdocs build --strict` - documentation builds successfully.