### PR TITLE
fix(ci): correct release bot identity and version bumping

### DIFF
--- a/.github/actions/configure-release-bot/action.yml
+++ b/.github/actions/configure-release-bot/action.yml
@@ -19,7 +19,8 @@ runs:
         RELEASE_BOT_APP_ID: ${{ inputs.bot-app-id }}
       run: |
         # Ensure bot name ends with [bot] for proper GitHub attribution
-        BOT_DISPLAY_NAME="${RELEASE_BOT_NAME%[bot]}[bot]"
+        # Note: Must quote '[bot]' to match literal string, not glob pattern
+        BOT_DISPLAY_NAME="${RELEASE_BOT_NAME%'[bot]'}[bot]"
         git config --global user.name "$BOT_DISPLAY_NAME"
         git config --global user.email "${RELEASE_BOT_APP_ID}+${BOT_DISPLAY_NAME}@users.noreply.github.com"
         echo "✅ Git configured with bot identity: $BOT_DISPLAY_NAME"

--- a/.github/scripts/bump-version.main.kts
+++ b/.github/scripts/bump-version.main.kts
@@ -218,6 +218,25 @@ fun updateFaktGradleSubplugin(newVersion: String) {
     }
 }
 
+fun updateLibsVersionsToml(newVersion: String) {
+    val tomlFile = File("gradle/libs.versions.toml")
+    if (!tomlFile.exists()) {
+        println("Warning: gradle/libs.versions.toml not found, skipping fakt version update")
+        return
+    }
+
+    val content = tomlFile.readText()
+    val versionPattern = Regex("""(fakt = )"[^"]+"""")
+    val updatedContent = versionPattern.replace(content) { matchResult ->
+        """${matchResult.groupValues[1]}"$newVersion""""
+    }
+
+    if (content != updatedContent) {
+        tomlFile.writeText(updatedContent)
+        println("Updated fakt version in libs.versions.toml to $newVersion")
+    }
+}
+
 fun addSnapshotSuffix(version: SemanticVersion): String {
     val versionString = version.toString()
     return if (versionString.endsWith("-SNAPSHOT")) {
@@ -253,6 +272,9 @@ fun main(args: Array<String>) {
         // Update PLUGIN_VERSION in FaktGradleSubplugin.kt
         updateFaktGradleSubplugin(snapshotVersion)
 
+        // Update fakt version in libs.versions.toml
+        updateLibsVersionsToml(snapshotVersion)
+
         // Output for GitHub Actions (if needed)
         println("VERSION_SNAPSHOT=$snapshotVersion")
         println("Current version converted to SNAPSHOT: $snapshotVersion")
@@ -282,6 +304,9 @@ fun main(args: Array<String>) {
 
     // Update PLUGIN_VERSION in FaktGradleSubplugin.kt
     updateFaktGradleSubplugin(newVersion.toString())
+
+    // Update fakt version in libs.versions.toml
+    updateLibsVersionsToml(newVersion.toString())
 
     // Output for GitHub Actions
     println("VERSION_CURRENT=$currentVersion")

--- a/.github/workflows/test-github-app.yml
+++ b/.github/workflows/test-github-app.yml
@@ -131,12 +131,19 @@ jobs:
         run: |
           echo "Testing Git configuration..."
 
-          git config --global user.name 'fakt-bot'
-          git config --global user.email 'bot@rsicarelli.dev'
+          # Use the actual release bot configuration
+          BOT_NAME="${{ vars.RELEASE_BOT_NAME }}"
+          BOT_USER_ID="${{ vars.RELEASE_BOT_APP_ID }}"
+
+          # Ensure bot name ends with [bot] for proper GitHub attribution
+          BOT_DISPLAY_NAME="${BOT_NAME%'[bot]'}[bot]"
+
+          git config --global user.name "$BOT_DISPLAY_NAME"
+          git config --global user.email "${BOT_USER_ID}+${BOT_DISPLAY_NAME}@users.noreply.github.com"
 
           echo "✅ Git user configured:"
-          git config user.name
-          git config user.email
+          echo "   Name: $(git config user.name)"
+          echo "   Email: $(git config user.email)"
 
   test-commit-capability:
     name: Test Commit and Push Capability
@@ -157,10 +164,11 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config --global user.name 'fakt-bot'
-          git config --global user.email 'bot@rsicarelli.dev'
+      - name: Configure Git with Release Bot Identity
+        uses: ./.github/actions/configure-release-bot
+        with:
+          bot-name: ${{ vars.RELEASE_BOT_NAME }}
+          bot-app-id: ${{ vars.RELEASE_BOT_APP_ID }}
 
       - name: Create Test Branch
         id: branch


### PR DESCRIPTION
## Description

Fixes multiple issues with the release bot configuration and version bumping script:
1. **Double `[bot]` suffix** - The bot was appearing as `fakt-release-bot[bot][bot]` because bash pattern `%[bot]` was interpreted as a character class instead of literal string
2. **Missing version location** - The `libs.versions.toml` file was not being updated by the version bump script, causing build failures when plugin version mismatched
3. **Bot avatar not showing** - Test workflow was using hardcoded values instead of actual bot config, making it impossible to verify proper GitHub App attribution

## Related Issue

N/A - Bug discovered during release process

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

### `.github/actions/configure-release-bot/action.yml`
- Quote bash pattern `'[bot]'` to match literal string instead of glob character class

### `.github/scripts/bump-version.main.kts`
- Add `updateLibsVersionsToml()` function to update `gradle/libs.versions.toml`
- Call new function in both snapshot mode and regular bump mode

### `.github/workflows/test-github-app.yml`
- Use `configure-release-bot` action instead of hardcoded git config
- Use repository variables for bot identity to properly test avatar attribution

## Pre-Submission Checklist

- [x] Tested version bump script locally (all 3 files updated correctly)
- [x] Tested GitHub App workflow with `create-test-branch` mode
- [x] Verified bot avatar shows correctly on commits
- [x] Verified no double `[bot][bot]` suffix

## Additional Context

**Before:** `fakt-release-bot[bot][bot]` (broken)  
**After:** `fakt-release-bot[bot]` with proper avatar ✅

The `RELEASE_BOT_APP_ID` repository variable was also updated from the App ID (`2442228`) to the Bot User ID (`248769216`) to enable proper avatar attribution.