### PR TITLE
docs: document configurable call history feature

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -267,6 +267,17 @@ Call counts are derived from thread-safe internal state.
 
 </td>
 </tr>
+<tr>
+<td><strong>Configurable</strong></td>
+<td>
+
+```kotlin
+@Fake(callHistory = CallHistoryMode.DISABLED)
+interface Logger { ... }  // Lightweight, no tracking
+```
+
+</td>
+</tr>
 </table>
 
 ---

--- a/docs/user-guide/generated-code-reference.md
+++ b/docs/user-guide/generated-code-reference.md
@@ -46,6 +46,9 @@ class Fake{Interface}Config(private val fake: Fake{Interface}Impl) {
 
 ## Call History Data Classes
 
+!!! note "Call History is Configurable"
+    The classes and properties described in this section are only generated when call history is enabled. See [Plugin Configuration](plugin-configuration.md#call-history-configuration) for details.
+
 For each method with parameters, Fakt generates a data class capturing all arguments:
 
 ```kotlin
@@ -144,6 +147,28 @@ fake.verifyTrack {
     assertTrue(neverCalledWith("error"))
 }
 ```
+
+---
+
+## Generated Code with Call History Disabled
+
+When call history is disabled via `enableCallHistory.set(false)` or `@Fake(callHistory = CallHistoryMode.DISABLED)`, generated fakes are simplified:
+
+**Generated:**
+
+- `Fake{Interface}Impl` - Implementation class
+- `fake{Interface}()` - Factory function
+- `Fake{Interface}Config` - Configuration DSL
+
+**Not Generated:**
+
+- `{method}CallCount` properties
+- `{method}CallHistory` lists
+- `Fake{Interface}{Method}Call` data classes
+- `Fake{Interface}{Method}Verifier` classes
+- `verify{Method}` extension functions
+
+This results in smaller, simpler generated code for fakes that only need stubbing.
 
 ---
 

--- a/docs/user-guide/plugin-configuration.md
+++ b/docs/user-guide/plugin-configuration.md
@@ -23,6 +23,9 @@ fakt {
     // Control logging verbosity (default: INFO)
     logLevel.set(LogLevel.INFO)  // Options: QUIET, INFO, DEBUG
 
+    // Control call history generation (default: true)
+    enableCallHistory.set(true)  // Set to false for lightweight fakes
+
     // Multi-module: Collect fakes from another module (default: not set)
     @OptIn(com.rsicarelli.fakt.compiler.api.ExperimentalFaktMultiModule::class)
     collectFakesFrom(projects.core.analytics)
@@ -56,6 +59,19 @@ fakt {
 ```kotlin
 fakt {
     logLevel.set(LogLevel.DEBUG)
+}
+```
+
+</td>
+</tr>
+<tr>
+<td><strong>enableCallHistory</strong></td>
+<td><code>true</code></td>
+<td>
+
+```kotlin
+fakt {
+    enableCallHistory.set(false)
 }
 ```
 
@@ -162,6 +178,76 @@ fakt {
 </td>
 </tr>
 </table>
+
+---
+
+## Call History Configuration
+
+Control whether generated fakes include call tracking and verification capabilities.
+
+<table>
+<tr><th>Setting</th><th>Description</th><th>Example</th></tr>
+<tr>
+<td><strong>true</strong><br>(default)</td>
+<td>
+
+Full call tracking with:
+
+- `methodNameCallCount` properties
+- `methodNameCallHistory` lists
+- `verifyMethodName { }` DSL
+
+</td>
+<td>
+
+```kotlin
+fakt {
+    enableCallHistory.set(true)
+}
+```
+
+</td>
+</tr>
+<tr>
+<td><strong>false</strong></td>
+<td>
+
+Lightweight fakes with only behavior configuration. No call tracking overhead.
+
+</td>
+<td>
+
+```kotlin
+fakt {
+    enableCallHistory.set(false)
+}
+```
+
+</td>
+</tr>
+</table>
+
+### Per-Interface Override
+
+Individual interfaces can override the project default:
+
+```kotlin
+import com.rsicarelli.fakt.CallHistoryMode
+
+// Always generate call history (even if plugin default is false)
+@Fake(callHistory = CallHistoryMode.ENABLED)
+interface PaymentService { ... }
+
+// Never generate call history (even if plugin default is true)
+@Fake(callHistory = CallHistoryMode.DISABLED)
+interface Logger { ... }
+
+// Follow plugin default
+@Fake  // or @Fake(callHistory = CallHistoryMode.DEFAULT)
+interface UserService { ... }
+```
+
+**Resolution order:** Annotation setting takes precedence over plugin default.
 
 ---
 

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -819,6 +819,85 @@ fun `GIVEN fake WHEN calling from multiple threads THEN counts correctly`() = ru
 
 ---
 
+### Configuring Call History
+
+By default, Fakt generates full call tracking for every fake. You can disable this for lightweight fakes that don't need verification.
+
+#### Project-Wide Default
+
+Configure the default for all fakes in your project:
+
+```kotlin
+// build.gradle.kts
+fakt {
+    enableCallHistory.set(false)  // Disable for all fakes by default
+}
+```
+
+#### Per-Interface Override
+
+Override the project default for specific interfaces:
+
+```kotlin
+import com.rsicarelli.fakt.CallHistoryMode
+
+// Disable call history for this interface (lightweight fake)
+@Fake(callHistory = CallHistoryMode.DISABLED)
+interface Logger {
+    fun log(message: String)
+}
+
+// Enable call history (even if plugin default is disabled)
+@Fake(callHistory = CallHistoryMode.ENABLED)
+interface PaymentService {
+    fun processPayment(amount: Double): Result<Receipt>
+}
+
+// Follow plugin default
+@Fake  // Same as @Fake(callHistory = CallHistoryMode.DEFAULT)
+interface UserService { ... }
+```
+
+#### When to Disable Call History
+
+Disable call history when:
+
+- Fakes are only used for stubbing, not verification
+- You want smaller generated code
+- Migrating legacy tests that don't need call tracking
+
+Enable call history when:
+
+- You need to verify method calls (`wasCalledTimes`, `wasCalledWith`)
+- Migrating from mocking frameworks (MockK, Mockito)
+- Testing interaction patterns
+
+#### What Changes
+
+**With call history enabled (default):**
+
+```kotlin
+val fake = fakeLogger()
+fake.log("message")
+
+assertEquals(1, fake.logCallCount)  // Available
+fake.verifyLog {                     // Available
+    assertTrue(wasCalledWith("message"))
+}
+```
+
+**With call history disabled:**
+
+```kotlin
+val fake = fakeLogger()
+fake.log("message")
+
+// fake.logCallCount         // Not generated
+// fake.verifyLog { ... }    // Not generated
+```
+
+---
+
 ## Advanced Patterns
 
 ### Inheritance

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -115,6 +115,9 @@ fakt {
     // Logging verbosity: QUIET, INFO, DEBUG
     logLevel.set(LogLevel.DEBUG)
 
+    // Call history generation (default: true)
+    enableCallHistory.set(true)  // Set to false for lightweight fakes
+
     // Use FIR-based analysis (experimental)
     useFirAnalysis.set(true)
 }


### PR DESCRIPTION
## Description

Documents the new configurable call history feature introduced in PR #39. This update covers the `enableCallHistory` Gradle property and per-interface `@Fake(callHistory = CallHistoryMode.XXX)` annotation override across all relevant documentation files.

## Related Issue

Closes #39

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

**Files updated:**

| File | Changes |
|------|---------|
| `docs/user-guide/plugin-configuration.md` | Added `enableCallHistory` to config reference, properties table, and new "Call History Configuration" section |
| `docs/user-guide/usage.md` | Added "Configuring Call History" subsection with project-wide and per-interface examples |
| `docs/user-guide/generated-code-reference.md` | Added note about conditional generation and "Generated Code with Call History Disabled" section |
| `docs/get-started/features.md` | Added "Configurable" row to Call Tracking & Verification table |
| `gradle-plugin/README.md` | Added `enableCallHistory` to Advanced Configuration example |