### PR TITLE
fix(ci): remove references to deleted validate-ktlint action

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run Ktlint
-        uses: ./.github/actions/validate-ktlint
-
       - name: Run Detekt
         uses: ./.github/actions/validate-detekt
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run Ktlint
-        uses: ./.github/actions/validate-ktlint
-
       - name: Run Detekt
         uses: ./.github/actions/validate-detekt
 


### PR DESCRIPTION
## Description

Publish workflows (`publish-release.yml` and `publish-hotfix.yml`) referenced the `.github/actions/validate-ktlint` composite action which no longer exists after migrating formatting validation to Spotless. This caused publish workflows to fail immediately.

Removes the stale ktlint steps — the `validate-spotless` action already covers formatting validation in both workflows.

## Type of Change
- [x] Bug fix

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] No breaking changes OR breaking changes documented