### PR TITLE
fix(ci): use fakt-release-bot identity for docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,9 +53,10 @@ jobs:
           pip install --requirement .github/workflows/mkdocs-requirements.txt
 
       - name: Configure Git for Mike
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        uses: ./.github/actions/configure-release-bot
+        with:
+          bot-name: ${{ vars.RELEASE_BOT_NAME }}
+          bot-app-id: ${{ vars.RELEASE_BOT_APP_ID }}
 
       - name: Show current Mike versions
         run: |


### PR DESCRIPTION
## Summary

- Reuse `configure-release-bot` action in `deploy-docs.yml` instead of hardcoded `github-actions[bot]` identity
- Aligns docs deployment with the same dynamic bot identity pattern used by `publish-release`, `publish-hotfix`, and `test-github-app` workflows
- Prevents `github-actions[bot]` from appearing as a repository contributor on future doc deploys

## Test plan

- [ ] Merge to main and verify the `gh-pages` commit uses `fakt-release-bot[bot]` identity