### PR TITLE
fix(cache): persist callHistoryMode through KMP metadata cache

### DIFF
--- a/compiler-api/api/compiler-api.api
+++ b/compiler-api/api/compiler-api.api
@@ -146,13 +146,14 @@ public final class com/rsicarelli/fakt/compiler/api/SerializableAnnotationInfo$C
 
 public final class com/rsicarelli/fakt/compiler/api/SerializableFakeClass {
 	public static final field Companion Lcom/rsicarelli/fakt/compiler/api/SerializableFakeClass$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()J
 	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
@@ -161,12 +162,13 @@ public final class com/rsicarelli/fakt/compiler/api/SerializableFakeClass {
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeClass;
-	public static synthetic fun copy$default (Lcom/rsicarelli/fakt/compiler/api/SerializableFakeClass;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeClass;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeClass;
+	public static synthetic fun copy$default (Lcom/rsicarelli/fakt/compiler/api/SerializableFakeClass;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeClass;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAbstractMethods ()Ljava/util/List;
 	public final fun getAbstractProperties ()Ljava/util/List;
 	public final fun getAnnotations ()Ljava/util/List;
+	public final fun getCallHistoryMode ()Ljava/lang/String;
 	public final fun getClassIdString ()Ljava/lang/String;
 	public final fun getOpenMethods ()Ljava/util/List;
 	public final fun getOpenProperties ()Ljava/util/List;
@@ -197,13 +199,14 @@ public final class com/rsicarelli/fakt/compiler/api/SerializableFakeClass$Compan
 
 public final class com/rsicarelli/fakt/compiler/api/SerializableFakeInterface {
 	public static final field Companion Lcom/rsicarelli/fakt/compiler/api/SerializableFakeInterface$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()J
 	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
@@ -212,10 +215,11 @@ public final class com/rsicarelli/fakt/compiler/api/SerializableFakeInterface {
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeInterface;
-	public static synthetic fun copy$default (Lcom/rsicarelli/fakt/compiler/api/SerializableFakeInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeInterface;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeInterface;
+	public static synthetic fun copy$default (Lcom/rsicarelli/fakt/compiler/api/SerializableFakeInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/rsicarelli/fakt/compiler/api/SerializableFakeInterface;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnnotations ()Ljava/util/List;
+	public final fun getCallHistoryMode ()Ljava/lang/String;
 	public final fun getClassIdString ()Ljava/lang/String;
 	public final fun getFunctions ()Ljava/util/List;
 	public final fun getInheritedFunctions ()Ljava/util/List;

--- a/compiler-api/src/main/kotlin/com/rsicarelli/fakt/compiler/api/FirMetadataCache.kt
+++ b/compiler-api/src/main/kotlin/com/rsicarelli/fakt/compiler/api/FirMetadataCache.kt
@@ -75,8 +75,10 @@ data class FirMetadataCache(
          * - Added visibility field for explicitApi() support (Issue #21)
          * - Added annotations support (Issue #22)
          * - Added isOptInMarker field for @RequiresOptIn detection (Issue #22)
+         * - v3:
+         * - Added callHistoryMode field for per-interface call history control
          */
-        const val CURRENT_VERSION: Int = 2
+        const val CURRENT_VERSION: Int = 3
     }
 }
 
@@ -98,6 +100,7 @@ data class FirMetadataCache(
  * @property sourceFileSignature MD5 hash of source file (for cache invalidation)
  * @property validationTimeNanos Time spent validating this interface in FIR phase
  * @property visibility Visibility modifier (PUBLIC, INTERNAL, etc.) for explicitApi() support
+ * @property callHistoryMode Call history generation mode (DEFAULT, ENABLED, DISABLED)
  */
 @Serializable
 data class SerializableFakeInterface(
@@ -114,6 +117,7 @@ data class SerializableFakeInterface(
     val sourceFileSignature: String,
     val validationTimeNanos: Long,
     val visibility: String = "PUBLIC",
+    val callHistoryMode: String = "DEFAULT",
 )
 
 /**
@@ -133,6 +137,7 @@ data class SerializableFakeInterface(
  * @property sourceFileSignature MD5 hash of source file
  * @property validationTimeNanos Time spent validating this class in FIR phase
  * @property visibility Visibility modifier (PUBLIC, INTERNAL, etc.) for explicitApi() support
+ * @property callHistoryMode Call history generation mode (DEFAULT, ENABLED, DISABLED)
  */
 @Serializable
 data class SerializableFakeClass(
@@ -149,6 +154,7 @@ data class SerializableFakeClass(
     val sourceFileSignature: String,
     val validationTimeNanos: Long,
     val visibility: String = "PUBLIC",
+    val callHistoryMode: String = "DEFAULT",
 )
 
 /**

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/fir/cache/MetadataCacheSerializer.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/fir/cache/MetadataCacheSerializer.kt
@@ -13,6 +13,7 @@ import com.rsicarelli.fakt.compiler.api.SerializablePropertyInfo
 import com.rsicarelli.fakt.compiler.api.SerializableTypeParameterInfo
 import com.rsicarelli.fakt.compiler.fir.metadata.FirAnnotationArgument
 import com.rsicarelli.fakt.compiler.fir.metadata.FirAnnotationInfo
+import com.rsicarelli.fakt.compiler.fir.metadata.FirCallHistoryMode
 import com.rsicarelli.fakt.compiler.fir.metadata.FirFunctionInfo
 import com.rsicarelli.fakt.compiler.fir.metadata.FirParameterInfo
 import com.rsicarelli.fakt.compiler.fir.metadata.FirPropertyInfo
@@ -90,6 +91,7 @@ object MetadataCacheSerializer {
             sourceFileSignature = sourceFileSignature,
             validationTimeNanos = validated.validationTimeNanos,
             visibility = validated.visibility.name,
+            callHistoryMode = validated.callHistoryMode.name,
         )
     }
 
@@ -111,6 +113,7 @@ object MetadataCacheSerializer {
             sourceFileSignature = sourceFileSignature,
             validationTimeNanos = validated.validationTimeNanos,
             visibility = validated.visibility.name,
+            callHistoryMode = validated.callHistoryMode.name,
         )
     }
 
@@ -160,6 +163,8 @@ object MetadataCacheSerializer {
             sourceSourceSet = sourceLocation.extractSourceSetName(),
             // Restore visibility from cache for explicitApi() support
             visibility = FirVisibility.valueOf(serializable.visibility),
+            // Restore call history mode from cache
+            callHistoryMode = FirCallHistoryMode.valueOf(serializable.callHistoryMode),
         )
     }
 
@@ -200,6 +205,8 @@ object MetadataCacheSerializer {
             sourceSourceSet = sourceLocation.extractSourceSetName(),
             // Restore visibility from cache for explicitApi() support
             visibility = FirVisibility.valueOf(serializable.visibility),
+            // Restore call history mode from cache
+            callHistoryMode = FirCallHistoryMode.valueOf(serializable.callHistoryMode),
         )
     }
 


### PR DESCRIPTION
## Description

`callHistoryMode` was not serialized in `MetadataCacheSerializer`, causing platform compilations to load cached FIR metadata with `callHistoryMode` defaulting to `FirCallHistoryMode.DEFAULT` (which resolves to enabled). This meant `@Fake(callHistory = CallHistoryMode.DISABLED)` was ignored in KMP projects — call history fields, tracking code, data classes, and verifiers were still generated.

### Changes
- Add `callHistoryMode: String` field to `SerializableFakeInterface` and `SerializableFakeClass` (default `"DEFAULT"` for backward compat with v2 caches)
- Serialize/deserialize `callHistoryMode` in `MetadataCacheSerializer` (`toSerializable` / `toValidated`)
- Bump `FirMetadataCache.CURRENT_VERSION` from 2 → 3
- Update public API dump

## Related Issue

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context
The `"DEFAULT"` default value on the new serializable fields ensures backward compatibility — v2 caches missing the field will deserialize correctly via `ignoreUnknownKeys = true` + kotlinx.serialization defaults.