### PR TITLE
fix(codegen): preserve type bounds in generic verify functions

### DIFF
--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/CallHistoryDsl.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/CallHistoryDsl.kt
@@ -246,13 +246,20 @@ internal fun CodeFileBuilder.verifyFunction(
         visibility.applyVisibility(this)
         isInline = true
 
-        // Add type parameters without constraints (just names)
-        // The constraints go in the where clause
+        // Add type parameters with constraints when present
+        // Complex constraints (Comparable, multiple) go in the where clause instead
         if (classTypeParameters.isNotEmpty()) {
+            val hasWhereClause = typeParams.whereClause.isNotEmpty()
             classTypeParameters.forEach { param ->
                 val cleanParam = param.removePrefix("out ").removePrefix("in ").trim()
                 val name = cleanParam.substringBefore(" :").trim()
-                typeParam(name)
+                if (!hasWhereClause) {
+                    val constraint =
+                        if (" :" in cleanParam) cleanParam.substringAfter(" :").trim() else null
+                    if (constraint != null) typeParam(name, constraint) else typeParam(name)
+                } else {
+                    typeParam(name)
+                }
             }
         }
 
@@ -300,13 +307,20 @@ internal fun CodeFileBuilder.unitVerifyFunction(
         visibility.applyVisibility(this)
         isInline = true
 
-        // Add type parameters without constraints (just names)
-        // The constraints go in the where clause
+        // Add type parameters with constraints when present
+        // Complex constraints (Comparable, multiple) go in the where clause instead
         if (classTypeParameters.isNotEmpty()) {
+            val hasWhereClause = typeParams.whereClause.isNotEmpty()
             classTypeParameters.forEach { param ->
                 val cleanParam = param.removePrefix("out ").removePrefix("in ").trim()
                 val name = cleanParam.substringBefore(" :").trim()
-                typeParam(name)
+                if (!hasWhereClause) {
+                    val constraint =
+                        if (" :" in cleanParam) cleanParam.substringAfter(" :").trim() else null
+                    if (constraint != null) typeParam(name, constraint) else typeParam(name)
+                } else {
+                    typeParam(name)
+                }
             }
         }
 

--- a/compiler/src/test/kotlin/com/rsicarelli/fakt/codegen/extensions/CallHistoryGeneratorTest.kt
+++ b/compiler/src/test/kotlin/com/rsicarelli/fakt/codegen/extensions/CallHistoryGeneratorTest.kt
@@ -283,6 +283,62 @@ class CallHistoryGeneratorTest {
         assertTrue(result.contains("FakeRepositoryImpl<T>.verifyClear"))
     }
 
+    @Test
+    fun `GIVEN bounded type parameters WHEN unitVerifyFunction THEN includes type bounds`() {
+        // GIVEN
+        val fakeClassName = "FakeConverterImpl"
+        val interfaceName = "Converter"
+        val methodName = "clear"
+        val typeParams = listOf("NetworkType : Any", "LocalType : Any")
+
+        // WHEN
+        val result =
+            codeFile("") {
+                    unitVerifyFunction(
+                        fakeClassName,
+                        interfaceName,
+                        methodName,
+                        FirVisibility.PUBLIC,
+                        typeParams,
+                    )
+                }
+                .renderToString()
+
+        // THEN
+        assertTrue(result.contains("<NetworkType : Any, LocalType : Any>"))
+        assertTrue(result.contains("FakeConverterImpl<NetworkType, LocalType>.verifyClear"))
+    }
+
+    // endregion
+
+    // region DSL-based verifyFunction
+
+    @Test
+    fun `GIVEN bounded type parameters WHEN verifyFunction THEN includes type bounds`() {
+        // GIVEN
+        val fakeClassName = "FakeConverterImpl"
+        val interfaceName = "Converter"
+        val methodName = "toDomain"
+        val typeParams = listOf("NetworkType : Any", "LocalType : Any")
+
+        // WHEN
+        val result =
+            codeFile("") {
+                    verifyFunction(
+                        fakeClassName,
+                        interfaceName,
+                        methodName,
+                        FirVisibility.PUBLIC,
+                        typeParams,
+                    )
+                }
+                .renderToString()
+
+        // THEN
+        assertTrue(result.contains("<NetworkType : Any, LocalType : Any>"))
+        assertTrue(result.contains("FakeConverterImpl<NetworkType, LocalType>.verifyToDomain"))
+    }
+
     // endregion
 
     // region generateCallHistoryDeclarations integration

--- a/samples/kmp-single-module/src/commonMain/kotlin/com/rsicarelli/fakt/samples/kmpSingleModule/scenarios/genericsConstraints/Converter.kt
+++ b/samples/kmp-single-module/src/commonMain/kotlin/com/rsicarelli/fakt/samples/kmpSingleModule/scenarios/genericsConstraints/Converter.kt
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.samples.kmpSingleModule.scenarios.genericsConstraints
+
+import com.rsicarelli.fakt.Fake
+
+/**
+ * Regression test for #61: Generic interface verify functions missing type bounds.
+ *
+ * Tests that bounded type parameters (`: Any`) are preserved in generated verify extension
+ * functions.
+ */
+@Fake
+interface Converter<NetworkType : Any, LocalType : Any> {
+    fun toDomain(network: NetworkType): LocalType?
+
+    fun clear()
+}

--- a/samples/kmp-single-module/src/commonTest/kotlin/com/rsicarelli/fakt/samples/kmpSingleModule/scenarios/genericsConstraints/ConverterTest.kt
+++ b/samples/kmp-single-module/src/commonTest/kotlin/com/rsicarelli/fakt/samples/kmpSingleModule/scenarios/genericsConstraints/ConverterTest.kt
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.samples.kmpSingleModule.scenarios.genericsConstraints
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ConverterTest {
+    @Test
+    fun `GIVEN converter with String to Int WHEN toDomain THEN returns configured value`() {
+        // Given
+        val converter = fakeConverter<String, Int> {
+            toDomain { network -> network.length }
+        }
+
+        // When
+        val result: Int? = converter.toDomain("hello")
+
+        // Then
+        assertEquals(5, result)
+    }
+
+    @Test
+    fun `GIVEN converter with defaults WHEN toDomain THEN returns null`() {
+        // Given
+        val converter = fakeConverter<String, Int>()
+
+        // When
+        val result: Int? = converter.toDomain("hello")
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `GIVEN converter WHEN verifyToDomain THEN tracks calls correctly`() {
+        // Given
+        val converter = fakeConverter<String, Int> {
+            toDomain { network -> network.length }
+        }
+
+        // When
+        converter.toDomain("hello")
+        converter.toDomain("world")
+
+        // Then
+        converter.verifyToDomain {
+            wasCalledTimes(2)
+        }
+    }
+
+    @Test
+    fun `GIVEN converter WHEN verifyClear THEN tracks calls correctly`() {
+        // Given
+        val converter = fakeConverter<String, Int>()
+
+        // When
+        converter.clear()
+
+        // Then
+        converter.verifyClear {
+            wasCalledTimes(1)
+        }
+    }
+}


### PR DESCRIPTION
## Description

When a `@Fake` interface has bounded type parameters (e.g. `<T : Any>`), the generated `verify*` and `unitVerify*` extension functions were emitting bare type parameters (`<T>`) instead of preserving the bounds (`<T : Any>`). This caused compilation errors in generated code.

**Root cause:** `verifyFunction()` and `unitVerifyFunction()` in `CallHistoryDsl.kt` called `typeParam(name)` unconditionally, stripping all constraints.

**Fix:** Parse bounds from `classTypeParameters` strings and emit `typeParam(name, constraint)` when a simple constraint exists. Complex constraints (e.g. multiple bounds or `Comparable`) fall back to a `where` clause.

## Related Issue

Fixes #61

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply`
- [ ] Linter passing: `./gradlew lintKotlin`
- [ ] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

Added a regression sample `genericsConstraints/Converter.kt` — a `@Fake` interface with two bounded type parameters `<NetworkType : Any, LocalType : Any>` — with 4 tests covering factory, defaults, `verifyToDomain`, and `verifyClear`.