### PR TITLE
fix: make gradle-plugin/compiler-api metadata compatible with Gradle's kotlin-dsl

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -27,6 +27,10 @@ dependencies {
     testImplementation(kotlin("test-junit5"))
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 gradlePlugin {
     plugins {
         register("fakt-root") {

--- a/build-logic/src/main/kotlin/com/rsicarelli/fakt/conventions/CommonConventions.kt
+++ b/build-logic/src/main/kotlin/com/rsicarelli/fakt/conventions/CommonConventions.kt
@@ -10,8 +10,9 @@ import org.gradle.api.Project
  * Applies the following conventions in order:
  * 1. JVM compilation (explicit Java 11 target, no toolchains)
  * 2. Kotlin compiler settings (progressive mode, JVM target, flags)
- * 3. Explicit API mode (for annotations module only)
- * 4. Test configuration (JUnit 5, parallel execution, memory settings)
+ * 3. Gradle compatibility (Kotlin 2.0 metadata for buildscript modules)
+ * 4. Explicit API mode (for annotations module only)
+ * 5. Test configuration (JUnit 5, parallel execution, memory settings)
  *
  * This is the main entry point for configuring Kotlin modules.
  * All logic is delegated to specific convention functions for modularity.
@@ -19,6 +20,7 @@ import org.gradle.api.Project
 fun Project.applyCommonConventions() {
     applyJvmCompilation()
     applyKotlinCompiler()
+    applyGradleCompatibility()
     applyExplicitApiForRuntime()
     applyTestConventions()
 }

--- a/build-logic/src/main/kotlin/com/rsicarelli/fakt/conventions/GradleCompatConvention.kt
+++ b/build-logic/src/main/kotlin/com/rsicarelli/fakt/conventions/GradleCompatConvention.kt
@@ -1,0 +1,53 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.conventions
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+/** Modules consumed on Gradle's buildscript classpath (kotlin-dsl). */
+private val GRADLE_COMPAT_MODULES = setOf("gradle-plugin", "compiler-api")
+
+/**
+ * Gradle buildscript compatibility convention.
+ *
+ * Configures Kotlin 2.0 language/API version for modules consumed on
+ * Gradle's buildscript classpath (`gradle-plugin`, `compiler-api`).
+ *
+ * Gradle 8.x embeds Kotlin 2.0.x in `kotlin-dsl`, which can only read
+ * metadata up to version 2.1.0. Without this, consumers get:
+ * "metadata version is 2.3.0, but compiler can read up to 2.1.0"
+ *
+ * Also:
+ * - Removes `-Xcontext-parameters` (requires Kotlin 2.2+, unused in these modules)
+ * - Prevents kotlin-stdlib from leaking into published POM (Gradle provides its own)
+ */
+fun Project.applyGradleCompatibility() {
+    if (name !in GRADLE_COMPAT_MODULES) return
+
+    // Prevent Kotlin Gradle Plugin from adding kotlin-stdlib as `implementation`.
+    // Must be set before afterEvaluate where KGP reads this property.
+    // Gradle's kotlin-dsl already provides stdlib via the embedded Kotlin compiler;
+    // including stdlib 2.3.20 would win version resolution over embedded 2.0.21.
+    extensions.extraProperties.set("kotlin.stdlib.default.dependency", "false")
+    dependencies.add("compileOnly", "org.jetbrains.kotlin:kotlin-stdlib")
+
+    kotlinJvmExtension {
+        compilerOptions {
+            apiVersion.set(KotlinVersion.KOTLIN_2_0)
+            languageVersion.set(KotlinVersion.KOTLIN_2_0)
+        }
+    }
+
+    // Override compiler flags set by KotlinCompilerConvention:
+    // - Disable progressive mode (only meaningful for latest language version)
+    // - Remove -Xcontext-parameters (requires Kotlin 2.2+, incompatible with
+    //   languageVersion 2.0). Keep -Xjsr305=strict for JVM null-safety.
+    tasks.withType(KotlinCompilationTask::class.java).configureEach {
+        compilerOptions {
+            progressiveMode.set(false)
+            freeCompilerArgs.set(listOf("-Xjsr305=strict"))
+        }
+    }
+}

--- a/build-logic/src/test/kotlin/com/rsicarelli/fakt/conventions/GradleCompatConventionTest.kt
+++ b/build-logic/src/test/kotlin/com/rsicarelli/fakt/conventions/GradleCompatConventionTest.kt
@@ -1,0 +1,99 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.conventions
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Unit tests for [applyGradleCompatibility].
+ *
+ * Tests apiVersion/languageVersion configuration via ProjectBuilder.
+ * kotlin-stdlib exclusion (via `kotlin.stdlib.default.dependency=false`) is
+ * verified by POM inspection after `publishToMavenLocal`.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GradleCompatConventionTest {
+
+    @Test
+    fun `GIVEN gradle-plugin module WHEN applying gradle compatibility THEN apiVersion is KOTLIN_2_0`() {
+        val project = ProjectBuilder.builder().withName("gradle-plugin").build()
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.applyGradleCompatibility()
+
+        val ext = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertEquals(KotlinVersion.KOTLIN_2_0, ext.compilerOptions.apiVersion.orNull)
+    }
+
+    @Test
+    fun `GIVEN gradle-plugin module WHEN applying gradle compatibility THEN languageVersion is KOTLIN_2_0`() {
+        val project = ProjectBuilder.builder().withName("gradle-plugin").build()
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.applyGradleCompatibility()
+
+        val ext = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertEquals(KotlinVersion.KOTLIN_2_0, ext.compilerOptions.languageVersion.orNull)
+    }
+
+    @Test
+    fun `GIVEN compiler-api module WHEN applying gradle compatibility THEN apiVersion is KOTLIN_2_0`() {
+        val project = ProjectBuilder.builder().withName("compiler-api").build()
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.applyGradleCompatibility()
+
+        val ext = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertEquals(KotlinVersion.KOTLIN_2_0, ext.compilerOptions.apiVersion.orNull)
+    }
+
+    @Test
+    fun `GIVEN compiler-api module WHEN applying gradle compatibility THEN languageVersion is KOTLIN_2_0`() {
+        val project = ProjectBuilder.builder().withName("compiler-api").build()
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.applyGradleCompatibility()
+
+        val ext = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertEquals(KotlinVersion.KOTLIN_2_0, ext.compilerOptions.languageVersion.orNull)
+    }
+
+    @Test
+    fun `GIVEN compiler module WHEN applying gradle compatibility THEN apiVersion is not set`() {
+        val project = ProjectBuilder.builder().withName("compiler").build()
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.applyGradleCompatibility()
+
+        val ext = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertNull(ext.compilerOptions.apiVersion.orNull)
+    }
+
+    @Test
+    fun `GIVEN compiler module WHEN applying gradle compatibility THEN languageVersion is not set`() {
+        val project = ProjectBuilder.builder().withName("compiler").build()
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.applyGradleCompatibility()
+
+        val ext = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertNull(ext.compilerOptions.languageVersion.orNull)
+    }
+
+    @Test
+    fun `GIVEN annotations module WHEN applying gradle compatibility THEN apiVersion is not set`() {
+        val project = ProjectBuilder.builder().withName("annotations").build()
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+
+        project.applyGradleCompatibility()
+
+        val ext = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertNull(ext.compilerOptions.apiVersion.orNull)
+    }
+}

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 description = "Fakt Gradle plugin for seamless build integration"
 
 dependencies {
-    // Compiler API for SourceSetContext serialization
-    implementation(projects.compilerApi)
+    // Compiler API — exposed as `api` so consumers can use LogLevel, etc.
+    api(projects.compilerApi)
 
     // Kotlin Gradle Plugin APIs (compileOnly like Metro)
     compileOnly(libs.kotlin.gradlePlugin)


### PR DESCRIPTION
## Description

Gradle 8.x embeds Kotlin 2.0.21 in `kotlin-dsl`, which reads metadata up to version 2.1.0. Fakt's `gradle-plugin` and `compiler-api` modules are compiled with Kotlin 2.3.20 (metadata 2.3.0), causing `Class was compiled with an incompatible version of Kotlin` errors when consumers add `compileOnly("com.rsicarelli.fakt:gradle-plugin")` in build-logic convention plugins.

Three root causes addressed:
1. **Metadata version 2.3.0** — both modules now emit Kotlin 2.0 metadata via `apiVersion`/`languageVersion = 2.0`
2. **kotlin-stdlib:2.3.20 leaking in POM** — wins version resolution over embedded 2.0.21; now excluded via `kotlin.stdlib.default.dependency=false`
3. **compiler-api with `runtime` scope** — `LogLevel` unresolvable at compile time; promoted to `api` scope

All changes centralized in a new `GradleCompatConvention` in build-logic — zero changes to module build scripts for the metadata/stdlib fix.

## Related Issue
Fixes #68

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [ ] Linter passing: `./gradlew lintKotlin`
- [ ] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

**Shortcut (if using Makefile):** `make format && make test`

## Additional Context

### Published POM verification (beta06)

**Before:**
- `kotlin-stdlib:2.3.20` with `compile` scope (breaks consumers)
- `compiler-api` with `runtime` scope (LogLevel unresolvable)

**After:**
- `kotlin-stdlib` — removed from POM entirely
- `compiler-api` — `compile` scope
- `kotlinx-serialization-json` — `runtime` scope (correct)

### Gradle module metadata (apiElements variant)

```
apiElements:
  com.rsicarelli.fakt:compiler-api  ← compile-time visible
runtimeElements:
  com.rsicarelli.fakt:compiler-api
  org.jetbrains.kotlinx:kotlinx-serialization-json
```

### Files changed

| File | Change |
|------|--------|
| `build-logic/.../GradleCompatConvention.kt` | New convention: Kotlin 2.0 compat + stdlib exclusion |
| `build-logic/.../GradleCompatConventionTest.kt` | 7 unit tests (GIVEN-WHEN-THEN, ProjectBuilder) |
| `build-logic/.../CommonConventions.kt` | Wire `applyGradleCompatibility()` into orchestrator |
| `build-logic/build.gradle.kts` | Enable JUnit 5 for build-logic tests |
| `gradle-plugin/build.gradle.kts` | `implementation` → `api` for compiler-api |

### Tested with
Consumer build-logic using `kotlin-dsl` (Gradle 8.14.3) successfully imports `FaktPluginExtension` and `LogLevel` via `compileOnly("com.rsicarelli.fakt:gradle-plugin:1.0.0-beta06")`.