### PR TITLE
ci: parallelize publish-release and publish-hotfix validations

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -12,8 +12,8 @@ env:
   ORG_GRADLE_PROJECT_RELEASE_MODE: true
 
 jobs:
-  guard-branch:
-    name: Guard Branch
+  guard-release:
+    name: Guard Release
     runs-on: ubuntu-latest
     steps:
       - name: Fail if branch is main
@@ -25,7 +25,7 @@ jobs:
 
   validate-detekt:
     name: Validate Detekt
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,7 +39,7 @@ jobs:
 
   validate-spotless:
     name: Validate Spotless
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
 
   validate-licenses:
     name: Validate Licenses
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -67,7 +67,7 @@ jobs:
 
   validate-api:
     name: Validate API
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,7 +81,7 @@ jobs:
 
   run-tests:
     name: Run Tests
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -105,7 +105,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -178,7 +178,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
-      - guard-branch
+      - guard-release
       - validate-detekt
       - validate-spotless
       - validate-licenses

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -12,8 +12,8 @@ env:
   ORG_GRADLE_PROJECT_RELEASE_MODE: true
 
 jobs:
-  validation:
-    name: Run Validations
+  guard-branch:
+    name: Guard Branch
     runs-on: ubuntu-latest
     steps:
       - name: Fail if branch is main
@@ -23,6 +23,11 @@ jobs:
           echo "Please create a hotfix branch (e.g., hotfix/1.2.x) and run from there"
           exit 1
 
+  validate-detekt:
+    name: Validate Detekt
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -32,25 +37,179 @@ jobs:
       - name: Run Detekt
         uses: ./.github/actions/validate-detekt
 
+  validate-spotless:
+    name: Validate Spotless
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
       - name: Run Spotless
         uses: ./.github/actions/validate-spotless
+
+  validate-licenses:
+    name: Validate Licenses
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Run License Check
         uses: ./.github/actions/validate-licenses
 
+  validate-api:
+    name: Validate API
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
-      - name: Run Tests
+  run-tests:
+    name: Run Tests
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Execute Tests
         uses: ./.github/actions/run-tests
 
-      - name: Test Samples
-        uses: ./.github/actions/test-samples
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-compiler
+          path: |
+            **/build/test-results/**/TEST-*.xml
+            !samples/**/build/test-results/**
+          retention-days: 1
+
+  test-samples:
+    name: Sample / ${{ matrix.sample }}
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sample: jvm-single-module
+            path: samples/jvm-single-module
+            tasks: build
+          - sample: android-single-module
+            path: samples/android-single-module
+            tasks: build
+          - sample: jvm-test-fixtures
+            path: samples/jvm-test-fixtures
+            tasks: build
+          - sample: kmp-single-module
+            path: samples/kmp-single-module
+            tasks: allTests --continue
+            check: true
+          - sample: kmp-multi-target
+            path: samples/kmp-multi-target
+            tasks: allTests --continue
+            check: true
+          - sample: kmp-multi-module
+            path: samples/kmp-multi-module
+            tasks: allTests --continue
+            check: true
+          - sample: fake-publishing
+            path: samples/fake-publishing/kmp-consumer
+            tasks: allTests --continue
+            check: true
+            pre-publish: samples/fake-publishing/kmp-publisher
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Regenerate JS/WASM lock files
+        run: ./gradlew kotlinUpgradePackageLock kotlinWasmUpgradePackageLock
+
+      - name: Publish Fakt plugin to Maven Local
+        env:
+          ORG_GRADLE_PROJECT_SKIP_SIGNING: true
+        run: ./gradlew publishToMavenLocal
+
+      - name: Pre-publish dependency
+        if: ${{ matrix.pre-publish }}
+        env:
+          ORG_GRADLE_PROJECT_SKIP_SIGNING: true
+        run: ./gradlew -p ${{ matrix.pre-publish }} publishToMavenLocal
+
+      - name: Test ${{ matrix.sample }}
+        run: ./gradlew -p ${{ matrix.path }} ${{ matrix.tasks }}
+
+      - name: Check ${{ matrix.sample }}
+        if: ${{ matrix.check }}
+        run: ./gradlew -p ${{ matrix.path }} check
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-sample-${{ matrix.sample }}
+          path: ${{ matrix.path }}/**/build/test-results/**/TEST-*.xml
+          retention-days: 1
+
+  validation-summary:
+    name: Validation Summary
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - guard-branch
+      - validate-detekt
+      - validate-spotless
+      - validate-licenses
+      - validate-api
+      - run-tests
+      - test-samples
+    steps:
+      - name: Check validation status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "❌ Some validation jobs failed"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were cancelled"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were skipped (upstream guard likely failed)"
+            exit 1
+          fi
+
+          echo "✅ All validation jobs passed successfully"
+          exit 0
 
   publish:
     name: Publish Hotfix to Maven Central
     runs-on: ubuntu-latest
-    needs: validation
+    needs: validation-summary
     outputs:
       version_published: ${{ steps.published.outputs.version }}
       version_new: ${{ steps.bump.outputs.version_new }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,8 +31,8 @@ env:
   ORG_GRADLE_PROJECT_RELEASE_MODE: true
 
 jobs:
-  guard-branch:
-    name: Guard Branch
+  guard-release:
+    name: Guard Release
     runs-on: ubuntu-latest
     steps:
       - name: Fail if branch is not main
@@ -43,7 +43,7 @@ jobs:
 
   validate-detekt:
     name: Validate Detekt
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
 
   validate-spotless:
     name: Validate Spotless
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -71,7 +71,7 @@ jobs:
 
   validate-licenses:
     name: Validate Licenses
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -85,7 +85,7 @@ jobs:
 
   validate-api:
     name: Validate API
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -99,7 +99,7 @@ jobs:
 
   run-tests:
     name: Run Tests
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -123,7 +123,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [guard-branch]
+    needs: [guard-release]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -196,7 +196,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
-      - guard-branch
+      - guard-release
       - validate-detekt
       - validate-spotless
       - validate-licenses

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,8 +31,8 @@ env:
   ORG_GRADLE_PROJECT_RELEASE_MODE: true
 
 jobs:
-  validation:
-    name: Run Validations
+  guard-branch:
+    name: Guard Branch
     runs-on: ubuntu-latest
     steps:
       - name: Fail if branch is not main
@@ -41,6 +41,11 @@ jobs:
           echo "This workflow should only be triggered from main/master branch"
           exit 1
 
+  validate-detekt:
+    name: Validate Detekt
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -50,25 +55,179 @@ jobs:
       - name: Run Detekt
         uses: ./.github/actions/validate-detekt
 
+  validate-spotless:
+    name: Validate Spotless
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
       - name: Run Spotless
         uses: ./.github/actions/validate-spotless
+
+  validate-licenses:
+    name: Validate Licenses
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Run License Check
         uses: ./.github/actions/validate-licenses
 
+  validate-api:
+    name: Validate API
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
-      - name: Run Tests
+  run-tests:
+    name: Run Tests
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Execute Tests
         uses: ./.github/actions/run-tests
 
-      - name: Test Samples
-        uses: ./.github/actions/test-samples
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-compiler
+          path: |
+            **/build/test-results/**/TEST-*.xml
+            !samples/**/build/test-results/**
+          retention-days: 1
+
+  test-samples:
+    name: Sample / ${{ matrix.sample }}
+    needs: [guard-branch]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sample: jvm-single-module
+            path: samples/jvm-single-module
+            tasks: build
+          - sample: android-single-module
+            path: samples/android-single-module
+            tasks: build
+          - sample: jvm-test-fixtures
+            path: samples/jvm-test-fixtures
+            tasks: build
+          - sample: kmp-single-module
+            path: samples/kmp-single-module
+            tasks: allTests --continue
+            check: true
+          - sample: kmp-multi-target
+            path: samples/kmp-multi-target
+            tasks: allTests --continue
+            check: true
+          - sample: kmp-multi-module
+            path: samples/kmp-multi-module
+            tasks: allTests --continue
+            check: true
+          - sample: fake-publishing
+            path: samples/fake-publishing/kmp-consumer
+            tasks: allTests --continue
+            check: true
+            pre-publish: samples/fake-publishing/kmp-publisher
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Regenerate JS/WASM lock files
+        run: ./gradlew kotlinUpgradePackageLock kotlinWasmUpgradePackageLock
+
+      - name: Publish Fakt plugin to Maven Local
+        env:
+          ORG_GRADLE_PROJECT_SKIP_SIGNING: true
+        run: ./gradlew publishToMavenLocal
+
+      - name: Pre-publish dependency
+        if: ${{ matrix.pre-publish }}
+        env:
+          ORG_GRADLE_PROJECT_SKIP_SIGNING: true
+        run: ./gradlew -p ${{ matrix.pre-publish }} publishToMavenLocal
+
+      - name: Test ${{ matrix.sample }}
+        run: ./gradlew -p ${{ matrix.path }} ${{ matrix.tasks }}
+
+      - name: Check ${{ matrix.sample }}
+        if: ${{ matrix.check }}
+        run: ./gradlew -p ${{ matrix.path }} check
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-sample-${{ matrix.sample }}
+          path: ${{ matrix.path }}/**/build/test-results/**/TEST-*.xml
+          retention-days: 1
+
+  validation-summary:
+    name: Validation Summary
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - guard-branch
+      - validate-detekt
+      - validate-spotless
+      - validate-licenses
+      - validate-api
+      - run-tests
+      - test-samples
+    steps:
+      - name: Check validation status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "❌ Some validation jobs failed"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were cancelled"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "⚠️  Some validation jobs were skipped (upstream guard likely failed)"
+            exit 1
+          fi
+
+          echo "✅ All validation jobs passed successfully"
+          exit 0
 
   publish:
     name: Publish to Maven Central
     runs-on: ubuntu-latest
-    needs: validation
+    needs: validation-summary
     outputs:
       version_published: ${{ steps.published.outputs.version }}
       version_new: ${{ steps.bump.outputs.version_new }}


### PR DESCRIPTION
## Description

Both publish workflows previously ran a single validation job with six sequential steps (`detekt → spotless → licenses → api → tests → test-samples`), and the seven sample projects inside the `test-samples` composite action also ran serially. Releases waited on the longest possible critical path.

This PR mirrors the parallel structure already proven in `development.yml`:

```
guard-branch
   ├─ validate-detekt    ┐
   ├─ validate-spotless  │
   ├─ validate-licenses  ├─→ validation-summary → publish → deploy-docs
   ├─ validate-api       │
   ├─ run-tests          │
   └─ test-samples (matrix × 7) ┘
```

- Five `validate-*` jobs run in parallel via the existing composite actions in `.github/actions/`.
- `test-samples` fans out to a 7-entry matrix (`fail-fast: false`) — one runner per sample.
- A `validation-summary` aggregator (`if: always()`) gates `publish` and explicitly fails on any `failure`, `cancelled`, or `skipped` upstream result, so a failed `guard-branch` cascade can't silently green-light publishing.
- Existing branch-restriction guards are preserved in a dedicated `guard-branch` job.

Wall time of the validation phase drops from `sum(detekt + spotless + licenses + api + tests + 7 × samples)` to `max(longest single job)`.

Scope intentionally kept tight: no new validations added (no `test-compat`), no changes to composite actions, no changes to `continuous-deploy.yml` or `fix-publication.yml`.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply` (workflow YAML only — no Kotlin changes)
- [x] Linter passing: `./gradlew lintKotlin` (no Kotlin changes)
- [x] Static analysis: `./gradlew detekt` (no Kotlin changes)
- [x] Tests added/updated and passing: `./gradlew test` (no Kotlin changes)
- [x] Generated code compiles (verified with sample project) (no Kotlin changes)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

**Shortcut (if using Makefile):** `make format && make test`

## Additional Context

- **Verification:** YAML parsed and job-dependency graph confirmed locally. Real validation happens on the next manual workflow_dispatch of `Publish Release` or `Publish Hotfix` — no PR-triggered run for these workflows.
- **Risk:** low. Composite actions (`validate-detekt`, `validate-spotless`, `validate-licenses`, `validate-api`, `run-tests`) are identical to those already run on every PR in `development.yml`. Sample matrix steps are copied verbatim from `development.yml:160-194`.
- **Out of scope:** `test-samples/action.yml` is left unchanged — still useful for local Make targets, just bypassed in CI.