### PR TITLE
ci: cache Gradle wrapper and remove broken setup-java cache

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -9,7 +9,6 @@ runs:
       with:
         distribution: 'temurin'
         java-version: '21'
-        cache: 'gradle'
 
     - name: Read Node.js version from .tool-versions
       id: node-version

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -38,6 +38,14 @@ runs:
         restore-keys: |
           ${{ runner.os }}-konan-
 
+    - name: Cache Gradle wrapper distributions
+      uses: actions/cache@v4
+      with:
+        path: ~/.gradle/wrapper/dists
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-wrapper-
+
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
       with:


### PR DESCRIPTION
## Description

Two related Gradle caching issues, fixed together because they share the same root cause and the same file:

### 1. `setup-java` `cache: 'gradle'` is broken and noisy

`actions/setup-java@v5` was configured with `cache: 'gradle'`. Its post-job cleanup invokes a non-existent `/usr/bin/gradle` (the runner only has `./gradlew`), causing this on every job:

```
Cache cleanup failed. Will continue.
Error: The process '/usr/bin/gradle' failed with exit code 1
```

The error is non-fatal but the cache layer is also non-functional — it doesn't reliably store anything useful, and it competes with `gradle/actions/setup-gradle@v6` for the same directories. The official `gradle/actions/setup-gradle` docs explicitly recommend dropping `setup-java`'s `cache: 'gradle'` when using `setup-gradle`.

**Fix:** remove `cache: 'gradle'` from the JDK setup step. `setup-gradle@v6` is already configured below it as the canonical cache provider.

### 2. Gradle wrapper distributions weren't cached anywhere

`gradle/actions/setup-gradle@v6` caches `~/.gradle/caches` (modules) and a few other paths but **does not** cache `~/.gradle/wrapper/dists`, where the unpacked Gradle distribution lives. Combined with the broken `setup-java` cache above, no layer covered the wrapper distribution — every fresh runner re-downloaded `gradle-9.0.0-bin.zip`.

This was most visible on `test-compat` matrix entries (one download × 7 Kotlin versions × every PR), but every CI job using `setup-environment` paid the cost.

**Fix:** add an explicit `actions/cache@v4` step keyed on the hash of every `gradle-wrapper.properties` in the repo:

```yaml
- name: Cache Gradle wrapper distributions
  uses: actions/cache@v4
  with:
    path: ~/.gradle/wrapper/dists
    key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
    restore-keys: |
      ${{ runner.os }}-gradle-wrapper-
```

Same Gradle versions across root + all samples + all compat samples = single shared cache entry that any main run populates and every PR can read. `restore-keys` give partial hits when one wrapper bumps independently.

### Why one PR

Both edits live in `.github/actions/setup-environment/action.yml`, both are about Gradle caching correctness, and they're complementary — removing the broken layer without adding the right one would leave wrapper downloads happening; adding the right one without removing the broken one would leave the misleading "Cache cleanup failed" warnings on every job.

## Related Issue
N/A — observed in the publish-release run logs and a recent PR run that re-downloaded `gradle-9.0.0-bin.zip` during `Test Compat Sample`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply` (workflow YAML only — no Kotlin changes)
- [x] Linter passing: `./gradlew lintKotlin` (no Kotlin changes)
- [x] Static analysis: `./gradlew detekt` (no Kotlin changes)
- [x] Tests added/updated and passing: `./gradlew test` (no Kotlin changes)
- [x] Generated code compiles (verified with sample project) (no Kotlin changes)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

- **Affects every workflow** that uses `setup-environment`: development, publish-release, publish-hotfix, continuous-deploy, fix-publication.
- **Cache size:** wrapper dists are ~150 MB per Gradle version. Single-version repo (9.0.0) → one cache entry, well within the 10 GB per-repo budget alongside the existing npm/Konan caches from #76 and #77.
- **Verification:** after merge, the first CI run on main populates the wrapper cache. Subsequent runs (PR or main) should NOT print `Downloading https://services.gradle.org/distributions/gradle-9.0.0-bin.zip`. The `Cache cleanup failed` warnings disappear on all jobs.
- **Risk:** low. If the wrapper cache key mismatches, the wrapper redownloads — same as today. Removing `setup-java`'s `cache: 'gradle'` only removes a layer that was already broken.
- **Follows:** PRs #76 / #77 / #78 (npm/Konan cache + plugin Maven Local sharing). This PR rounds out the Gradle caching story for CI.
