### PR TITLE
ci: cache Kotlin/JS node distribution and npm packages

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -21,6 +21,16 @@ runs:
       with:
         node-version: ${{ steps.node-version.outputs.version }}
 
+    - name: Cache Kotlin/JS node + npm packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/nodejs
+          ~/.npm
+        key: ${{ runner.os }}-kotlin-js-${{ hashFiles('gradle/libs.versions.toml', '.tool-versions') }}
+        restore-keys: |
+          ${{ runner.os }}-kotlin-js-
+
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
       with:


### PR DESCRIPTION
## Description

Every CI job that uses `setup-environment` currently re-downloads the Kotlin/JS Node distribution and refetches npm packages from scratch. Two paths are uncached today:

- `~/.gradle/nodejs` — the Node distribution Kotlin/JS installs. Not covered by `gradle/actions/setup-gradle@v6`, which only caches `~/.gradle/caches` and `~/.gradle/wrapper`.
- `~/.npm` — npm's own package cache. Kotlin/JS uses npm here, not yarn (`kotlin.js.yarn=false` in `gradle.properties`), and `actions/setup-node@v6` has no `cache` option set.

This adds one `actions/cache@v4` step to the shared `setup-environment` composite, keyed on `gradle/libs.versions.toml` (Kotlin version) and `.tool-versions` (Node version). Restore-keys allow partial hits across version bumps. All five workflows that use `setup-environment` (development, publish-release, publish-hotfix, continuous-deploy, fix-publication) inherit the cache automatically — no per-workflow editing.

**Expected impact:** ~30–90s saved per sample matrix job × 7 ≈ 3.5–10 min runner-min per CI run. Marginal wall-time impact.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply` (workflow YAML only — no Kotlin changes)
- [x] Linter passing: `./gradlew lintKotlin` (no Kotlin changes)
- [x] Static analysis: `./gradlew detekt` (no Kotlin changes)
- [x] Tests added/updated and passing: `./gradlew test` (no Kotlin changes)
- [x] Generated code compiles (verified with sample project) (no Kotlin changes)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

- **Risk:** very low. If the cache is wrong, `kotlinUpgradePackageLock` regenerates and Gradle redownloads — same as today.
- **Cache size:** ~50–150 MB. Well within GitHub's 10 GB per-repo budget.
- **Verification:** the cache step shows `Cache hit: false` on the first run and `Cache hit: true` on subsequent runs after main has populated it. Sample matrix jobs should show shorter `kotlinUpgradePackageLock` step times.
- **First in a series:** PR #77 (Konan cache) and PR #78 (plugin Maven Local sharing) follow.
