### PR TITLE
ci: cache Konan compiler and native dependencies

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -31,6 +31,14 @@ runs:
         restore-keys: |
           ${{ runner.os }}-kotlin-js-
 
+    - name: Cache Konan compiler and dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.konan
+        key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-konan-
+
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
       with:


### PR DESCRIPTION
## Description

The Kotlin/Native toolchain (Konan compiler, LLVM, libffi, platform sysroots) lives in `~/.konan` and is downloaded fresh by every KMP matrix job. `gradle/actions/setup-gradle@v6` only caches `~/.gradle/caches` and `~/.gradle/wrapper` — `~/.konan` is uncovered.

This is the biggest single cost on the critical path. On the recent publish-release run, `kmp-multi-module` took 11m49s — several minutes of that are Konan downloads, repeated independently across all KMP samples (`kmp-single-module`, `kmp-multi-target`, `kmp-multi-module`, `fake-publishing`).

This PR adds one `actions/cache@v4` step to the shared `setup-environment` composite:

- **Path:** `~/.konan`
- **Key:** binds to `gradle/libs.versions.toml` (currently `kotlin = 2.3.20`) — invalidates on Kotlin upgrade
- **Restore-keys:** allow partial hits across version bumps so we don't fully redownload on minor changes

All five workflows that use `setup-environment` inherit the cache automatically.

**Expected impact:** 3–5 min off `kmp-multi-module` (the current critical path). ~9–15 min runner-min per CI run.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply` (workflow YAML only — no Kotlin changes)
- [x] Linter passing: `./gradlew lintKotlin` (no Kotlin changes)
- [x] Static analysis: `./gradlew detekt` (no Kotlin changes)
- [x] Tests added/updated and passing: `./gradlew test` (no Kotlin changes)
- [x] Generated code compiles (verified with sample project) (no Kotlin changes)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

- **Risk:** low. The 4 KMP samples that disable Gradle's config/build cache (compiler-plugin compat) are the canaries — watch them after merge. If a stale cache breaks one, bumping the key invalidates instantly.
- **Cache size:** `~/.konan` grows to several hundred MB across all targets. Well within the 10 GB per-repo budget alongside #76.
- **Verification:** KMP sample logs should no longer print `Downloading native dependency llvm` / `Downloading native dependency lldb` lines after the first cache-populating run on main.
- **Second in a series:** PR #76 (npm/node cache) is the first; PR #78 (plugin Maven Local sharing) follows.
