### PR TITLE
ci: share Fakt plugin Maven Local across sample matrix

### DIFF
--- a/.github/actions/publish-plugin-bundle/action.yml
+++ b/.github/actions/publish-plugin-bundle/action.yml
@@ -1,0 +1,29 @@
+name: Publish Plugin Bundle
+description: Build the Fakt plugin, publish to Maven Local, and upload the artifacts as a workflow artifact for downstream sample jobs
+
+inputs:
+  artifact-name:
+    description: Name of the workflow artifact that holds the published Maven Local subtree
+    required: false
+    default: fakt-plugin-maven-local
+
+runs:
+  using: composite
+  steps:
+    - name: Regenerate JS/WASM lock files
+      shell: bash
+      run: ./gradlew kotlinUpgradePackageLock kotlinWasmUpgradePackageLock
+
+    - name: Publish Fakt plugin to Maven Local
+      shell: bash
+      env:
+        ORG_GRADLE_PROJECT_SKIP_SIGNING: true
+      run: ./gradlew publishToMavenLocal
+
+    - name: Upload plugin Maven Local subtree
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ~/.m2/repository/com/rsicarelli/fakt/
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/actions/restore-plugin-bundle/action.yml
+++ b/.github/actions/restore-plugin-bundle/action.yml
@@ -1,0 +1,23 @@
+name: Restore Plugin Bundle
+description: Download the Fakt plugin Maven Local subtree published by the upstream build-plugin job and install it into the runner's local Maven repository
+
+inputs:
+  artifact-name:
+    description: Name of the workflow artifact that holds the published Maven Local subtree
+    required: false
+    default: fakt-plugin-maven-local
+
+runs:
+  using: composite
+  steps:
+    - name: Download plugin Maven Local subtree
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/fakt-plugin
+
+    - name: Install into local Maven repository
+      shell: bash
+      run: |
+        mkdir -p ~/.m2/repository/com/rsicarelli/fakt
+        cp -R "${{ runner.temp }}/fakt-plugin/." ~/.m2/repository/com/rsicarelli/fakt/

--- a/.github/actions/restore-plugin-bundle/action.yml
+++ b/.github/actions/restore-plugin-bundle/action.yml
@@ -1,5 +1,5 @@
 name: Restore Plugin Bundle
-description: Download the Fakt plugin Maven Local subtree published by the upstream build-plugin job and install it into the runner's local Maven repository
+description: Download the Fakt plugin Maven Local subtree published by the upstream publish-plugin-bundle job and install it into the runner's local Maven repository
 
 inputs:
   artifact-name:

--- a/.github/actions/test-compat-samples/action.yml
+++ b/.github/actions/test-compat-samples/action.yml
@@ -9,15 +9,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Clean stale Fakt artifacts
-      shell: bash
-      run: rm -rf ~/.m2/repository/com/rsicarelli/fakt/
-
-    - name: Publish Fakt plugin to Maven Local
-      shell: bash
-      env:
-        ORG_GRADLE_PROJECT_SKIP_SIGNING: true
-      run: ./gradlew clean publishToMavenLocal --no-daemon --no-build-cache --no-configuration-cache
+    - name: Restore Plugin Bundle
+      uses: ./.github/actions/restore-plugin-bundle
 
     - name: Test compat sample (Kotlin ${{ inputs.kotlin-version }})
       shell: bash

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -97,8 +97,8 @@ jobs:
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
-  build-plugin:
-    name: Build Plugin
+  publish-plugin-bundle:
+    name: Publish Plugin Bundle
     needs: [check-code-changes]
     if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
@@ -139,7 +139,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [check-code-changes, build-plugin]
+    needs: [check-code-changes, publish-plugin-bundle]
     if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     strategy:
@@ -205,7 +205,7 @@ jobs:
 
   test-compat:
     name: Compat / Kotlin ${{ matrix.kotlin-version }}
-    needs: [check-code-changes]
+    needs: [check-code-changes, publish-plugin-bundle]
     if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     strategy:
@@ -242,7 +242,7 @@ jobs:
       - validate-licenses
       - validate-api
       - run-tests
-      - build-plugin
+      - publish-plugin-bundle
       - test-samples
       - test-compat
     steps:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -97,6 +97,21 @@ jobs:
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
+  build-plugin:
+    name: Build Plugin
+    needs: [check-code-changes]
+    if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Publish Plugin Bundle
+        uses: ./.github/actions/publish-plugin-bundle
+
   run-tests:
     name: Run Tests
     needs: [check-code-changes]
@@ -124,7 +139,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [check-code-changes]
+    needs: [check-code-changes, build-plugin]
     if: ${{ needs.check-code-changes.outputs.has-changes == 'true' }}
     runs-on: ubuntu-latest
     strategy:
@@ -164,13 +179,8 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Regenerate JS/WASM lock files
-        run: ./gradlew kotlinUpgradePackageLock kotlinWasmUpgradePackageLock
-
-      - name: Publish Fakt plugin to Maven Local
-        env:
-          ORG_GRADLE_PROJECT_SKIP_SIGNING: true
-        run: ./gradlew publishToMavenLocal
+      - name: Restore Plugin Bundle
+        uses: ./.github/actions/restore-plugin-bundle
 
       - name: Pre-publish dependency
         if: ${{ matrix.pre-publish }}
@@ -232,6 +242,7 @@ jobs:
       - validate-licenses
       - validate-api
       - run-tests
+      - build-plugin
       - test-samples
       - test-compat
     steps:

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
-  build-plugin:
-    name: Build Plugin
+  publish-plugin-bundle:
+    name: Publish Plugin Bundle
     needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
@@ -119,7 +119,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [guard-release, build-plugin]
+    needs: [guard-release, publish-plugin-bundle]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -193,7 +193,7 @@ jobs:
       - validate-licenses
       - validate-api
       - run-tests
-      - build-plugin
+      - publish-plugin-bundle
       - test-samples
     steps:
       - name: Check validation status

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -79,6 +79,20 @@ jobs:
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
+  build-plugin:
+    name: Build Plugin
+    needs: [guard-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Publish Plugin Bundle
+        uses: ./.github/actions/publish-plugin-bundle
+
   run-tests:
     name: Run Tests
     needs: [guard-release]
@@ -105,7 +119,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [guard-release]
+    needs: [guard-release, build-plugin]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -144,13 +158,8 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Regenerate JS/WASM lock files
-        run: ./gradlew kotlinUpgradePackageLock kotlinWasmUpgradePackageLock
-
-      - name: Publish Fakt plugin to Maven Local
-        env:
-          ORG_GRADLE_PROJECT_SKIP_SIGNING: true
-        run: ./gradlew publishToMavenLocal
+      - name: Restore Plugin Bundle
+        uses: ./.github/actions/restore-plugin-bundle
 
       - name: Pre-publish dependency
         if: ${{ matrix.pre-publish }}
@@ -184,6 +193,7 @@ jobs:
       - validate-licenses
       - validate-api
       - run-tests
+      - build-plugin
       - test-samples
     steps:
       - name: Check validation status

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -97,6 +97,20 @@ jobs:
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
+  build-plugin:
+    name: Build Plugin
+    needs: [guard-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Publish Plugin Bundle
+        uses: ./.github/actions/publish-plugin-bundle
+
   run-tests:
     name: Run Tests
     needs: [guard-release]
@@ -123,7 +137,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [guard-release]
+    needs: [guard-release, build-plugin]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -162,13 +176,8 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Regenerate JS/WASM lock files
-        run: ./gradlew kotlinUpgradePackageLock kotlinWasmUpgradePackageLock
-
-      - name: Publish Fakt plugin to Maven Local
-        env:
-          ORG_GRADLE_PROJECT_SKIP_SIGNING: true
-        run: ./gradlew publishToMavenLocal
+      - name: Restore Plugin Bundle
+        uses: ./.github/actions/restore-plugin-bundle
 
       - name: Pre-publish dependency
         if: ${{ matrix.pre-publish }}
@@ -202,6 +211,7 @@ jobs:
       - validate-licenses
       - validate-api
       - run-tests
+      - build-plugin
       - test-samples
     steps:
       - name: Check validation status

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -97,8 +97,8 @@ jobs:
       - name: Run API Check
         uses: ./.github/actions/validate-api
 
-  build-plugin:
-    name: Build Plugin
+  publish-plugin-bundle:
+    name: Publish Plugin Bundle
     needs: [guard-release]
     runs-on: ubuntu-latest
     steps:
@@ -137,7 +137,7 @@ jobs:
 
   test-samples:
     name: Sample / ${{ matrix.sample }}
-    needs: [guard-release, build-plugin]
+    needs: [guard-release, publish-plugin-bundle]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -211,7 +211,7 @@ jobs:
       - validate-licenses
       - validate-api
       - run-tests
-      - build-plugin
+      - publish-plugin-bundle
       - test-samples
     steps:
       - name: Check validation status


### PR DESCRIPTION
## Description

Each of the 7 `test-samples` matrix entries plus all 7 `test-compat` matrix entries previously ran `publishToMavenLocal` independently — building and publishing the same identical plugin artifacts up to 14 times per CI run, costing tens of minutes of duplicated runner-minutes per release.

This PR hoists the plugin build into a single upstream `publish-plugin-bundle` job that publishes once and uploads `~/.m2/repository/com/rsicarelli/fakt/` as a workflow artifact. Both `test-samples` and `test-compat` matrix entries then download that artifact and install it into the runner's local Maven repo before running their tests.

`publish-plugin-bundle` runs in parallel with the `validate-*` jobs (gated by `guard-release` / `check-code-changes`), so it doesn't extend the critical path beyond what the validates already need. Only `test-samples` and `test-compat` wait on it. The aggregator (`validation-summary` / `ci-summary`) gains `publish-plugin-bundle` as a dependency so a build failure properly fails the workflow.

## New composites (reused across all sample/compat matrix jobs)

- **`publish-plugin-bundle`** — regenerates lock files, runs `publishToMavenLocal`, uploads the Fakt subtree as an artifact. Used by the upstream job of the same name.
- **`restore-plugin-bundle`** — downloads the artifact and copies it into the runner's Maven Local. Used in each `test-samples` matrix entry and inside the existing `test-compat-samples` composite.

The `fake-publishing` sample's separate `kmp-publisher` pre-publish step is unchanged — it publishes a sample-specific artifact, not Fakt.

## test-compat refactor

The `test-compat-samples` composite previously wiped `~/.m2/repository/com/rsicarelli/fakt/` and ran `./gradlew clean publishToMavenLocal --no-build-cache --no-configuration-cache` on every compat matrix entry. With the shared bundle in place that's redundant — each compat job now restores the artifact via `restore-plugin-bundle` and runs only the compat sample's `jvmTest`.

## Workflows affected

`development.yml`, `publish-release.yml`, `publish-hotfix.yml`. `continuous-deploy.yml` and `fix-publication.yml` don't run sample matrices and are untouched.

**Expected impact:** ~25–45 min runner-min saved per CI run (sample matrix + compat matrix combined). Wall-time stays roughly the same on publish-release (publish-plugin-bundle becomes a serial gate of ~4–5 min); development.yml wall-time may improve because compat jobs no longer publish.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply` (workflow YAML only — no Kotlin changes)
- [x] Linter passing: `./gradlew lintKotlin` (no Kotlin changes)
- [x] Static analysis: `./gradlew detekt` (no Kotlin changes)
- [x] Tests added/updated and passing: `./gradlew test` (no Kotlin changes)
- [x] Generated code compiles (verified with sample project) (no Kotlin changes)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

- **Risk:** moderate. Adds a new dependency edge — if the artifact upload fails, all matrix jobs fail. The composite uses `if-no-files-found: error` to surface upload-time issues immediately rather than silently producing an empty artifact.
- **Verification:** in the run summary, `publish-plugin-bundle` shows once, no matrix entry runs `kotlinUpgradePackageLock` / `publishToMavenLocal`, total runner-min for the workflow drops sharply.
- **Third in a series:** PR #76 (npm/node cache) and PR #77 (Konan cache) are first. Order matters — those two also speed up `publish-plugin-bundle` itself, so savings here compound on top.
- **Reverting:** isolated. Reverting this PR brings back the old per-matrix steps without touching the cache work.
