### PR TITLE
docs(github): trim welcome SLA to match q-a.yml tone

### DIFF
--- a/.github/discussions/welcome.md
+++ b/.github/discussions/welcome.md
@@ -29,8 +29,9 @@ Reproducible bugs and regressions still go to [Issues](../../issues).
 
 ## ⏱ Expectations
 
-Fakt is pre-1.0 with a **single maintainer**. Q&A first-response target is
-**5 business days**. Show & tell has no SLA — reactions when seen.
+Fakt is pre-1.0 with a **single maintainer**. Q&A is best-effort; well-formed
+posts (with version info + a reproducer) get answered first. Show & tell has
+no SLA — reactions when seen.
 
 If you open an Issue that's actually a question, expect it to be converted
 to a Discussion. It's not a rejection — it's filing.


### PR DESCRIPTION
## Description

Aligns the Welcome announcement draft with the looser SLA wording the linter already applied to `q-a.yml` in #81. Drops the "5 business days" hard promise and replaces it with a best-effort framing that nudges posters toward well-formed reports (version + reproducer) instead of setting a time commitment.

## Related Issue
Follow-up to #81.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: N/A (markdown only)
- [x] Linter passing: N/A
- [x] Static analysis: N/A
- [x] Tests added/updated and passing: N/A
- [x] Generated code compiles: N/A
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented (none)

## Additional Context

The Welcome announcement hasn't been posted yet, so this only updates the in-repo source draft. Once this merges I'll create the actual pinned discussion via `gh` so the public post matches the trimmed wording.