### PR TITLE
docs(github): fix welcome paragraph line wraps

### DIFF
--- a/.github/discussions/welcome.md
+++ b/.github/discussions/welcome.md
@@ -1,18 +1,19 @@
 <!--
-Source for the pinned Welcome announcement in
-https://github.com/rsicarelli/fakt/discussions
+Source for the pinned Welcome announcement in https://github.com/rsicarelli/fakt/discussions
 
 Copy/paste this content into the 📣 Announcements category when refreshing.
+Each paragraph below is intentionally on a single long line — GitHub Discussions
+renders soft newlines as hard `<br>` breaks, so wrapping mid-paragraph would
+break the live post.
+
 Last refreshed: 2026-05-09.
 -->
 
 # Welcome to Fakt Discussions 👋
 
-Fakt is a Kotlin compiler plugin that generates type-safe test fakes from
-`@Fake` interfaces, FIR → IR, KMP-first.
+Fakt is a Kotlin compiler plugin that generates type-safe test fakes from `@Fake` interfaces, FIR → IR, KMP-first.
 
-This is the place for **questions, design conversations, and showing off**.
-Reproducible bugs and regressions still go to [Issues](../../issues).
+This is the place for **questions, design conversations, and showing off**. Reproducible bugs and regressions still go to [Issues](../../issues).
 
 ## 🧭 Where to post what
 
@@ -29,9 +30,6 @@ Reproducible bugs and regressions still go to [Issues](../../issues).
 
 ## ⏱ Expectations
 
-Fakt is pre-1.0 with a **single maintainer**. Q&A is best-effort; well-formed
-posts (with version info + a reproducer) get answered first. Show & tell has
-no SLA — reactions when seen.
+Fakt is pre-1.0 with a **single maintainer**. Q&A is best-effort; well-formed posts (with version info + a reproducer) get answered first. Show & tell has no SLA — reactions when seen.
 
-If you open an Issue that's actually a question, expect it to be converted
-to a Discussion. It's not a rejection — it's filing.
+If you open an Issue that's actually a question, expect it to be converted to a Discussion. It's not a rejection — it's filing.


### PR DESCRIPTION
## Description

The Welcome announcement (#83) was rendering with mid-paragraph line breaks because GitHub Discussions treats soft newlines in body text as hard `<br>` (different from how repository `.md` files render). Reformat each paragraph in `.github/discussions/welcome.md` to a single long line so the rendered post reflows to the reader's width. Live discussion #83 was updated to match in the same change.

Source comment now documents the constraint so future refreshes don't re-introduce 80-char wraps.

## Related Issue
Follow-up to #81 / #82.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: N/A (markdown only)
- [x] Linter passing: N/A
- [x] Static analysis: N/A
- [x] Tests added/updated and passing: N/A
- [x] Generated code compiles: N/A
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented (none)

## Additional Context

Verify visually after merge: https://github.com/rsicarelli/fakt/discussions/83 should render each `## ` section's body as flowing paragraphs, not stair-stepped lines.