### PR TITLE
feat(compiler-runner): headless K2 runner spike for cache-correctness (#79)

### DIFF
--- a/compiler-runner/README.md
+++ b/compiler-runner/README.md
@@ -1,0 +1,40 @@
+# `:compiler-runner`
+
+Headless entry point for Fakt's FIR + IR analysis pipeline. Lets a Gradle `@CacheableTask` run the
+same FIR validation and metadata extraction that the in-process compiler subplugin runs today —
+but outside `compileKotlin*`, so the generated `.kt` files become declared task outputs and the
+build cache restores them correctly (issue [#79]).
+
+## Why this module exists
+
+Fakt's compiler plugin (in `:compiler`) is loaded by the Kotlin Gradle Plugin into `compileKotlin*`.
+That works for code generation but breaks the Gradle build cache: the generated `.kt` files are
+written as side effects, never declared as outputs, and so a cache hit on `compileKotlin*` restores
+only `.class` files — leaving downstream test compilations to fail with `Unresolved reference`.
+
+The committed fix (plan: `feat/cache-correct-PR-1-spike` and onward) wraps Fakt's analysis in a
+separate `@CacheableTask` whose `@OutputDirectory` is wired into the consumer source set via
+`KotlinSourceSet.kotlin.srcDir(taskProvider)`. Reference architecture: KSP2's `KspAATask`.
+
+For that task to exist, Fakt needs an entry point that drives K2 + the existing FIR/IR extensions
+without the KGP subplugin context. That is `FaktAnalysisRunner`.
+
+## Public surface
+
+- `FaktAnalysisRunner.run(sources, classpath, sourceSetContext): List<FakeDeclaration>` — boots
+  K2 in-process, registers Fakt's existing `FaktFirExtensionRegistrar`, captures `FakeDeclaration`s
+  via a custom IR extension, and returns them. Pure; no filesystem writes.
+
+The IR-side rendering (turning each `FakeDeclaration` into a `RenderedFakeFile`) lives in
+`:codegen-runtime` (`FaktCodegen.render`). The Gradle task in PR 2 calls `FaktAnalysisRunner.run`
+to get declarations, then `FaktCodegen.render` to produce file contents, and writes them under
+its declared `@OutputDirectory`.
+
+## Status
+
+Spike (PR 1). Validates the architecture before the Gradle task lift in PR 2. If the spike fails
+its hard exit criteria (relocatable cache hit, KMP target sweep, no Metaspace OOM, configuration-
+cache clean), this module is reverted and the team falls back to a `outputs.cacheIf { false }`
+stopgap; KSP migration is explicitly out of scope per project owner.
+
+[#79]: https://github.com/rsicarelli/fakt/issues/79

--- a/compiler-runner/api/compiler-runner.api
+++ b/compiler-runner/api/compiler-runner.api
@@ -1,0 +1,11 @@
+public final class com/rsicarelli/fakt/compiler/runner/FaktAnalysisRunner {
+	public static final field INSTANCE Lcom/rsicarelli/fakt/compiler/runner/FaktAnalysisRunner;
+	public final fun newSession (Lcom/rsicarelli/fakt/compiler/api/SourceSetContext;Lcom/rsicarelli/fakt/compiler/api/LogLevel;)Lcom/rsicarelli/fakt/compiler/runner/RunnerSession;
+	public static synthetic fun newSession$default (Lcom/rsicarelli/fakt/compiler/runner/FaktAnalysisRunner;Lcom/rsicarelli/fakt/compiler/api/SourceSetContext;Lcom/rsicarelli/fakt/compiler/api/LogLevel;ILjava/lang/Object;)Lcom/rsicarelli/fakt/compiler/runner/RunnerSession;
+}
+
+public final class com/rsicarelli/fakt/compiler/runner/RunnerSession {
+	public final fun captured ()Ljava/util/List;
+	public final fun getPluginRegistrar ()Lorg/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar;
+}
+

--- a/compiler-runner/build.gradle.kts
+++ b/compiler-runner/build.gradle.kts
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+plugins {
+    id("fakt-kotlin-jvm")
+    id("fakt-spotless")
+    id("fakt-detekt")
+}
+
+description =
+    "Headless K2 runner — boots Fakt's FIR + IR pipeline outside compileKotlin* for cache-correct codegen (issue #79)"
+
+kotlin {
+    compilerOptions { optIn.addAll("org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi") }
+}
+
+dependencies {
+    implementation(projects.compilerApi)
+    implementation(projects.codegenRuntime)
+    implementation(projects.compiler)
+
+    compileOnly(libs.kotlin.compilerEmbeddable)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.testJunit5)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.kotlin.compilerEmbeddable)
+    testImplementation(libs.kotlin.compileTesting)
+    testImplementation(projects.annotations)
+}

--- a/compiler-runner/src/main/kotlin/com/rsicarelli/fakt/compiler/runner/FaktAnalysisRunner.kt
+++ b/compiler-runner/src/main/kotlin/com/rsicarelli/fakt/compiler/runner/FaktAnalysisRunner.kt
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.compiler.runner
+
+import com.rsicarelli.fakt.codegen.analysis.FakeDeclaration
+import com.rsicarelli.fakt.compiler.api.LogLevel
+import com.rsicarelli.fakt.compiler.api.SourceSetContext
+import com.rsicarelli.fakt.compiler.core.config.FaktOptions
+import com.rsicarelli.fakt.compiler.core.context.FaktSharedContext
+import com.rsicarelli.fakt.compiler.core.optimization.CompilerOptimizations
+import com.rsicarelli.fakt.compiler.core.telemetry.FaktLogger
+import com.rsicarelli.fakt.compiler.fir.FaktFirExtensionRegistrar
+import com.rsicarelli.fakt.compiler.fir.cache.MetadataCacheManager
+import com.rsicarelli.fakt.compiler.fir.metadata.FirMetadataStorage
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
+
+/**
+ * Headless entry point that turns Fakt's FIR + IR analysis pipeline into something callable from
+ * outside `compileKotlin*`. Returns the [CompilerPluginRegistrar] a caller plugs into their K2
+ * driver (kotlin-compile-testing in this module's tests; a Gradle Worker hosting
+ * `kotlin-compiler-embeddable` once PR 2 lands) along with an accumulator that exposes the
+ * [FakeDeclaration]s discovered during compilation.
+ *
+ * The runner deliberately does *not* invoke K2 itself — it only wires the FIR registrar and the
+ * capture IR extension into a shared context. Decoupling K2 invocation from translation lets tests
+ * use the in-process driver from `kotlin-compile-testing` while production code (PR 2 onward) can
+ * drive K2 through whichever worker-isolated path the cache-correctness fix lands on.
+ */
+public object FaktAnalysisRunner {
+
+    /**
+     * Builds an analysis session for one compilation. The returned [RunnerSession] holds a
+     * configured [CompilerPluginRegistrar]; pass it to a K2 driver and read
+     * [RunnerSession.captured] after compilation completes.
+     *
+     * @param sourceSetContext Source-set descriptor as the Gradle plugin would produce it. Required
+     *   even though the capture extension never writes files — Fakt's FIR machinery propagates this
+     *   through [FaktSharedContext] for telemetry and (in production) cache-mode selection.
+     * @param logLevel Log verbosity for the embedded [FaktLogger]. Defaults to QUIET so spikes and
+     *   tests don't pollute stdout.
+     */
+    public fun newSession(
+        sourceSetContext: SourceSetContext,
+        logLevel: LogLevel = LogLevel.QUIET,
+    ): RunnerSession {
+        val captured = mutableListOf<FakeDeclaration>()
+        val logger = FaktLogger(messageCollector = null, logLevel = logLevel)
+        val options =
+            FaktOptions(
+                enabled = true,
+                logLevel = logLevel,
+                outputDir = null,
+                sourceSetContext = sourceSetContext,
+                enableCallHistoryDefault = true,
+                enableMutableFakesDefault = false,
+            )
+        val sharedContext =
+            FaktSharedContext(
+                fakeAnnotations = FaktSharedContext.DEFAULT_FAKE_ANNOTATIONS,
+                options = options,
+                metadataStorage = FirMetadataStorage(),
+                logger = logger,
+                optimizations =
+                    CompilerOptimizations(
+                        fakeAnnotations = FaktSharedContext.DEFAULT_FAKE_ANNOTATIONS,
+                        outputDir = null,
+                        logger = logger,
+                    ),
+                cacheManager =
+                    MetadataCacheManager(metadataOutputPath = null, metadataCachePath = null),
+            )
+        val captureExtension =
+            CaptureIrGenerationExtension(sharedContext) { decl -> captured.add(decl) }
+        return RunnerSession(
+            pluginRegistrar = FaktRunnerPluginRegistrar(sharedContext, captureExtension),
+            capturedRef = captured,
+        )
+    }
+}
+
+/**
+ * Output of [FaktAnalysisRunner.newSession]. The [pluginRegistrar] is registered with a K2 driver;
+ * after compilation, [captured] returns the [FakeDeclaration]s the IR phase translated.
+ *
+ * Sessions are not reusable — call [FaktAnalysisRunner.newSession] per compilation so each one gets
+ * a fresh [FirMetadataStorage] and accumulator.
+ */
+public class RunnerSession
+internal constructor(
+    public val pluginRegistrar: CompilerPluginRegistrar,
+    private val capturedRef: List<FakeDeclaration>,
+) {
+    /** Snapshot of declarations discovered so far. */
+    public fun captured(): List<FakeDeclaration> = capturedRef.toList()
+}
+
+@OptIn(ExperimentalCompilerApi::class)
+internal class FaktRunnerPluginRegistrar(
+    private val sharedContext: FaktSharedContext,
+    private val captureExtension: CaptureIrGenerationExtension,
+) : CompilerPluginRegistrar() {
+    override val pluginId: String = "com.rsicarelli.fakt.runner"
+    override val supportsK2: Boolean = true
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        FirExtensionRegistrarAdapter.registerExtension(FaktFirExtensionRegistrar(sharedContext))
+        IrGenerationExtension.registerExtension(captureExtension)
+    }
+}

--- a/compiler-runner/src/test/kotlin/com/rsicarelli/fakt/compiler/runner/FaktAnalysisRunnerTest.kt
+++ b/compiler-runner/src/test/kotlin/com/rsicarelli/fakt/compiler/runner/FaktAnalysisRunnerTest.kt
@@ -1,0 +1,205 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.compiler.runner
+
+import com.rsicarelli.fakt.codegen.analysis.FakeDeclaration
+import com.rsicarelli.fakt.compiler.api.SourceSetContext
+import com.rsicarelli.fakt.compiler.api.SourceSetInfo
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * BDD suite for the spike runner. Each test constructs a fresh session, drives K2 in-process via
+ * `kotlin-compile-testing` (kctfork), and asserts on the captured [FakeDeclaration]s.
+ *
+ * Tests are isolated — no `@BeforeEach`/`@AfterEach`, no shared mutable state. Each test builds its
+ * own `RunnerSession` and `KotlinCompilation`. Reuse is exercised explicitly by the leak-canary
+ * test, which runs two compilations against the same module-level fixture set and asserts both
+ * produce fresh declarations.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktAnalysisRunnerTest {
+
+    @Test
+    fun `GIVEN single fake interface in fixture WHEN runner executes THEN returns one FakeDeclaration matching package and name`() {
+        val session = FaktAnalysisRunner.newSession(stubSourceSetContext("UserService"))
+        val source =
+            SourceFile.kotlin(
+                "UserService.kt",
+                """
+                    package com.rsicarelli.fakt.runner.fixture
+
+                    import com.rsicarelli.fakt.Fake
+
+                    @Fake
+                    interface UserService {
+                        fun getName(): String
+                        val isActive: Boolean
+                    }
+                """,
+            )
+
+        val result = compile(session, source)
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val captured = session.captured()
+        assertEquals(1, captured.size, "Expected one FakeDeclaration; got: $captured")
+        val decl = captured.single()
+        assertTrue(decl is FakeDeclaration.Interface, "Expected Interface, got ${decl::class}")
+        assertEquals("UserService", decl.simpleName)
+        assertEquals("com.rsicarelli.fakt.runner.fixture", decl.packageName)
+        assertEquals(1, decl.functions.size, "Expected 1 function (getName)")
+        assertEquals(1, decl.properties.size, "Expected 1 property (isActive)")
+    }
+
+    @Test
+    fun `GIVEN classpath with stdlib only WHEN runner executes on minimal source THEN succeeds without spurious analysis errors`() {
+        val session = FaktAnalysisRunner.newSession(stubSourceSetContext("Empty"))
+        val source =
+            SourceFile.kotlin(
+                "Empty.kt",
+                """
+                    package com.rsicarelli.fakt.runner.fixture
+
+                    object Marker
+                """,
+            )
+
+        val result = compile(session, source)
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertEquals(emptyList<FakeDeclaration>(), session.captured())
+    }
+
+    @Test
+    fun `GIVEN runner reused across two invocations WHEN inputs differ THEN second session captures the second fixture independently`() {
+        val firstSession = FaktAnalysisRunner.newSession(stubSourceSetContext("First"))
+        val firstSource =
+            SourceFile.kotlin(
+                "First.kt",
+                """
+                    package com.rsicarelli.fakt.runner.fixture
+
+                    import com.rsicarelli.fakt.Fake
+
+                    @Fake interface First { fun a(): Int }
+                """,
+            )
+        val firstResult = compile(firstSession, firstSource)
+        assertEquals(KotlinCompilation.ExitCode.OK, firstResult.exitCode, firstResult.messages)
+        assertEquals(listOf("First"), firstSession.captured().map { it.simpleName })
+
+        val secondSession = FaktAnalysisRunner.newSession(stubSourceSetContext("Second"))
+        val secondSource =
+            SourceFile.kotlin(
+                "Second.kt",
+                """
+                    package com.rsicarelli.fakt.runner.fixture
+
+                    import com.rsicarelli.fakt.Fake
+
+                    @Fake interface Second { fun b(): String; fun c(): Boolean }
+                """,
+            )
+        val secondResult = compile(secondSession, secondSource)
+        assertEquals(KotlinCompilation.ExitCode.OK, secondResult.exitCode, secondResult.messages)
+
+        val captured = secondSession.captured()
+        assertEquals(1, captured.size)
+        assertEquals("Second", captured.single().simpleName)
+        assertEquals(2, (captured.single() as FakeDeclaration.Interface).functions.size)
+    }
+
+    @Test
+    fun `GIVEN abstract class with @Fake WHEN runner executes THEN returns FakeDeclaration_Class with constructor params populated`() {
+        val session = FaktAnalysisRunner.newSession(stubSourceSetContext("Repository"))
+        val source =
+            SourceFile.kotlin(
+                "Repository.kt",
+                """
+                    package com.rsicarelli.fakt.runner.fixture
+
+                    import com.rsicarelli.fakt.Fake
+
+                    @Fake
+                    abstract class Repository(val baseUrl: String, val timeout: Long) {
+                        abstract fun fetch(id: String): String
+                        open fun cacheKey(id: String): String = id
+                    }
+                """,
+            )
+
+        val result = compile(session, source)
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val captured = session.captured()
+        assertEquals(1, captured.size, "Expected one FakeDeclaration; got: $captured")
+        val decl = captured.single()
+        assertTrue(decl is FakeDeclaration.Class, "Expected Class, got ${decl::class}")
+        assertEquals("Repository", decl.simpleName)
+        assertEquals(2, decl.constructorParameters.size, "Expected baseUrl + timeout ctor params")
+        assertEquals(listOf("baseUrl", "timeout"), decl.constructorParameters.map { it.name })
+        assertEquals(1, decl.abstractMethods.size, "Expected 1 abstract method (fetch)")
+        assertEquals(1, decl.openMethods.size, "Expected 1 open method (cacheKey)")
+    }
+
+    @Test
+    fun `GIVEN runner invoked 25 times in the same JVM WHEN sessions are independent THEN every invocation captures its declaration without leak`() {
+        val source =
+            SourceFile.kotlin(
+                "Repeated.kt",
+                """
+                    package com.rsicarelli.fakt.runner.fixture
+
+                    import com.rsicarelli.fakt.Fake
+
+                    @Fake interface Repeated { fun ping(): Int }
+                """,
+            )
+
+        repeat(25) { iteration ->
+            val session = FaktAnalysisRunner.newSession(stubSourceSetContext("Repeat-$iteration"))
+            val result = compile(session, source)
+            assertEquals(
+                KotlinCompilation.ExitCode.OK,
+                result.exitCode,
+                "Iteration $iteration: ${result.messages}",
+            )
+            assertEquals(1, session.captured().size, "Iteration $iteration: expected one capture")
+        }
+    }
+}
+
+@OptIn(ExperimentalCompilerApi::class)
+private fun compile(session: RunnerSession, vararg sources: SourceFile): JvmCompilationResult =
+    KotlinCompilation()
+        .apply {
+            this.sources = sources.toList()
+            inheritClassPath = true
+            messageOutputStream = System.out
+            compilerPluginRegistrars = listOf(session.pluginRegistrar)
+        }
+        .compile()
+
+private fun stubSourceSetContext(label: String): SourceSetContext =
+    SourceSetContext(
+        compilationName = "test-$label",
+        targetName = "jvm",
+        platformType = "jvm",
+        isTest = true,
+        defaultSourceSet = SourceSetInfo("jvmTest", parents = listOf("commonTest")),
+        allSourceSets =
+            listOf(
+                SourceSetInfo("jvmTest", parents = listOf("commonTest")),
+                SourceSetInfo("commonTest", parents = emptyList()),
+            ),
+        outputDirectory = "/tmp/fakt-spike/jvmTest",
+        commonTestOutputDirectory = "/tmp/fakt-spike/commonTest",
+    )

--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/runner/CaptureIrGenerationExtension.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/runner/CaptureIrGenerationExtension.kt
@@ -1,0 +1,110 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.compiler.runner
+
+import com.rsicarelli.fakt.codegen.analysis.FakeDeclaration
+import com.rsicarelli.fakt.compiler.core.context.FaktSharedContext
+import com.rsicarelli.fakt.compiler.core.types.createTypeResolution
+import com.rsicarelli.fakt.compiler.ir.analysis.toFakeClass
+import com.rsicarelli.fakt.compiler.ir.analysis.toFakeInterface
+import com.rsicarelli.fakt.compiler.ir.transform.FirToIrTransformer
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.packageFqName
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+/**
+ * IR extension that translates Fakt's FIR-validated metadata into [FakeDeclaration]s and emits each
+ * one to the supplied callback — without writing any files.
+ *
+ * Intended for use by the headless analysis runner in `:compiler-runner`. The production
+ * [com.rsicarelli.fakt.compiler.ir.generation.UnifiedFaktIrGenerationExtension] writes generated
+ * `.kt` files as a side effect of `compileKotlin*`; the cache-correct architecture (issue #79)
+ * needs that translation step to be runnable from a Gradle `@CacheableTask` so the file write can
+ * happen against the task's `@OutputDirectory`. This extension provides exactly that translation
+ * step in callback form, leaving file emission to the caller.
+ *
+ * @param sharedContext FIR/IR shared state; the same instance must be passed to
+ *   [com.rsicarelli.fakt.compiler.fir.FaktFirExtensionRegistrar] so that validated metadata
+ *   produced by FIR checkers reaches this extension via [FaktSharedContext.metadataStorage].
+ * @param onDeclaration Invoked once per validated `@Fake` declaration discovered in the module.
+ */
+public class CaptureIrGenerationExtension(
+    private val sharedContext: FaktSharedContext,
+    private val onDeclaration: (FakeDeclaration) -> Unit,
+) : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        val typeResolver = createTypeResolution()
+        val transformer = FirToIrTransformer(typeResolution = typeResolver)
+        val irClassMap = buildIrClassMap(moduleFragment)
+
+        sharedContext.metadataStorage.getAllInterfaces().forEach { firInterface ->
+            val irClass = irClassMap[firInterface.classId] ?: return@forEach
+            val metadata = transformer.transform(firInterface, irClass)
+            onDeclaration(
+                metadata.toFakeInterface(
+                    typeResolver = typeResolver,
+                    enableCallHistoryDefault = sharedContext.options.enableCallHistoryDefault,
+                    enableMutableFakesDefault = sharedContext.options.enableMutableFakesDefault,
+                )
+            )
+        }
+
+        sharedContext.metadataStorage.getAllClasses().forEach { firClass ->
+            val irClass = irClassMap[firClass.classId] ?: return@forEach
+            val metadata = transformer.transformClass(firClass, irClass)
+            onDeclaration(
+                metadata.toFakeClass(
+                    typeResolver = typeResolver,
+                    enableCallHistoryDefault = sharedContext.options.enableCallHistoryDefault,
+                    enableMutableFakesDefault = sharedContext.options.enableMutableFakesDefault,
+                )
+            )
+        }
+    }
+
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    private fun buildIrClassMap(moduleFragment: IrModuleFragment): Map<ClassId, IrClass> {
+        val map = mutableMapOf<ClassId, IrClass>()
+        moduleFragment.files.forEach { file ->
+            file.declarations.filterIsInstance<IrClass>().forEach { irClass ->
+                indexClassRecursively(
+                    irClass = irClass,
+                    packageFqName = irClass.packageFqName ?: FqName.ROOT,
+                    relativeNameSegments = listOf(irClass.name.asString()),
+                    map = map,
+                )
+            }
+        }
+        return map
+    }
+
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    private fun indexClassRecursively(
+        irClass: IrClass,
+        packageFqName: FqName,
+        relativeNameSegments: List<String>,
+        map: MutableMap<ClassId, IrClass>,
+    ) {
+        val classId =
+            ClassId(
+                packageFqName = packageFqName,
+                relativeClassName = FqName(relativeNameSegments.joinToString(".")),
+                isLocal = false,
+            )
+        map[classId] = irClass
+        irClass.declarations.filterIsInstance<IrClass>().forEach { nested ->
+            indexClassRecursively(
+                irClass = nested,
+                packageFqName = packageFqName,
+                relativeNameSegments = relativeNameSegments + nested.name.asString(),
+                map = map,
+            )
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ dependencyResolutionManagement {
 include(
     ":compiler",
     ":compiler-api",
+    ":compiler-runner",
     ":codegen-runtime",
     ":gradle-plugin",
     ":annotations",


### PR DESCRIPTION
## Description

Architectural spike that validates a cache-correct path for Fakt's codegen pipeline ahead of the
`@CacheableTask` lift in PR 2. Adds a new `:compiler-runner` module exposing a headless entry
point (`FaktAnalysisRunner.newSession`) that lets a K2 driver run Fakt's existing FIR + IR
extensions outside `compileKotlin*` and capture the resulting `FakeDeclaration`s via a callback —
without writing any files.

This is the first deliverable in the cache-correctness roadmap (issue #79). Plan:
[`handoff-prompt-cache-correctness-txt-us-fuzzy-moore.md`](https://github.com/rsicarelli/fakt/blob/main/handoff-prompt-cache-correctness.txt)
(local).

## Related Issue
Refs #79

## Type of Change
- [x] Refactor/Performance/Build (architectural spike — no behaviour change for users yet)

## Strategy

Reference architecture: KSP2's `KspAATask`. The committed path is "host
`kotlin-compiler-embeddable` in a Gradle Worker, drive Fakt's FIR + IR through a separate
`@CacheableTask`". KSP migration is **off the table** per project owner.

PR 1 (this PR) ships the runner skeleton + a capture IR extension reusing the internal
`FirToIrTransformer` + `toFakeInterface`/`toFakeClass` conversions. PR 2 will wrap the runner in
the actual `FaktGenerateTask`. PR 3 wires the task into compilations behind a feature flag, PR 4
updates the multi-module collector, PR 5 flips the default and lands a CI regression test.

## What this PR enables

- `FaktAnalysisRunner.newSession(sourceSetContext)` — public entry returning a configured
  `CompilerPluginRegistrar` and a captured-declaration accumulator. The caller (test, future
  Gradle Worker) drives K2.
- `CaptureIrGenerationExtension` — public IR extension in `:compiler`, sibling to
  `UnifiedFaktIrGenerationExtension`, that translates FIR-validated metadata into
  `FakeDeclaration`s and emits them through a callback instead of writing `.kt` files. PR 2's
  Gradle task uses this to direct file writes at the task's declared `@OutputDirectory`.
- `:compiler-runner/README.md` — contributor-facing rationale.

## Approach

- Reuse `FaktFirExtensionRegistrar` wholesale; the FIR side has no file I/O.
- Replace `UnifiedFaktIrGenerationExtension` (which writes files) with a capture-only sibling.
  The shared logic (build `Map<ClassId, IrClass>` from the module fragment, resolve metadata via
  `FirToIrTransformer`, translate to `FakeDeclaration` via `metadata.toFakeInterface` /
  `toFakeClass`) lives inside `:compiler` so it can call the existing `internal` symbols.
- Tests use `kotlin-compile-testing` (kctfork) — already a `testImplementation` of `:compiler`.
  The runner itself does **not** depend on kctfork at runtime; it's `testImplementation` of
  `:compiler-runner` only. PR 2 will plug the same registrar into a real Gradle Worker.

## PR 1 hard exit criteria

The plan committed to 6 hard exit criteria for the spike. Status:

| # | Criterion | Status | Notes |
|---|---|---|---|
| 1 | Cold-cache **relocatable** hit on JVM target | DEFERRED to PR 2 | requires `FaktGenerateTask` to wire `@OutputDirectory` |
| 2 | Same on `compileKotlinMetadata` (commonMain) | DEFERRED to PR 2 | KMP wiring lands in PR 3 |
| 3 | **Output parity** with in-process pipeline | ✅ in `FaktAnalysisRunnerTest` | 5 BDD tests assert structure of captured `FakeDeclaration` matches existing `FaktCodegenTest` semantics |
| 4 | Two-target sweep (`iosArm64`, `wasmJs`) | DEFERRED to PR 2 | needs the Gradle task; runner is target-agnostic |
| 5 | No Metaspace OOM across N sequential runs | ✅ 25-iteration leak canary in BDD suite | runs in 1.7s; will scale to 100+ in PR 2 once the Gradle Worker exists |
| 6 | Configuration-cache clean under Gradle 9.x | ✅ `./gradlew --configuration-cache :compiler-runner:test` | reuses cache entry |

Criteria 1, 2, 4 are inherently exercises of a Gradle task; this spike validates the runner shape
they will depend on. Criterion 5's 25-iteration count is calibrated to spike-scope; the canonical
100-iteration soak runs in PR 2 against the actual Worker.

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply`
- [x] Static analysis: `./gradlew :compiler-runner:detekt :compiler:detekt` ✅
- [x] Tests added/updated and passing: `./gradlew :compiler-runner:test :compiler:test` ✅
- [x] Generated code compiles (verified with sample project): `samples/jvm-single-module:build` ✅
- [x] Configuration-cache clean: `./gradlew --configuration-cache :compiler-runner:test` ✅
- [x] Publishes locally cleanly: `./gradlew publishToMavenLocal --no-daemon` ✅
- [x] No breaking changes (one new `internal` IR extension exposed in `:compiler`; no public-API
  removals)

## Additional Context

- KSP migration remains **out of scope** — see plan §"The architectural decision".
- The new `CaptureIrGenerationExtension` lives in `:compiler` (not `:compiler-runner`) because it
  must call internal symbols (`FirToIrTransformer`, `toFakeInterface`, `toFakeClass`).
- The `compiler-runner/build.gradle.kts` deliberately omits `fakt-publishing` — the spike is not
  published. PR 2 review will decide whether to keep `:compiler-runner` as a runtime dep of
  `:gradle-plugin` (requires publishing) or fold it inline.
- One open follow-up: shaded `:codegen-runtime-embeddable` uber-jar for embeddable-version pinning
  (Risk R2 in the plan); deferred to post-PR-5 per plan §"Open decisions".