### PR TITLE
feat(gradle-plugin): FaktGenerateTask @CacheableTask for issue #79

### DIFF
--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -33,6 +33,23 @@ public final class com/rsicarelli/fakt/gradle/FakeCollectorTask$Companion$Collec
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class com/rsicarelli/fakt/gradle/FaktGenerateTask : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/workers/WorkerExecutor;)V
+	public final fun generate ()V
+	public abstract fun getCommonFirMetadata ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getCompileClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getFaktCompilerClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getFaktVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getFaktWorkerClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getFirMetadataFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getGeneratedKotlinDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getImports ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getLogLevel ()Lorg/gradle/api/provider/Property;
+	public abstract fun getScratchDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getSourceSetContextJson ()Lorg/gradle/api/provider/Property;
+	public abstract fun getSources ()Lorg/gradle/api/file/ConfigurableFileCollection;
+}
+
 public final class com/rsicarelli/fakt/gradle/FaktGradleSubplugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
 	public static final field Companion Lcom/rsicarelli/fakt/gradle/FaktGradleSubplugin$Companion;
 	public static final field PLUGIN_ARTIFACT_NAME Ljava/lang/String;
@@ -76,5 +93,24 @@ public final class com/rsicarelli/fakt/gradle/GradleFaktLogger {
 public final class com/rsicarelli/fakt/gradle/SourceSetDiscoveryKt {
 	public static final fun getAllParentSourceSets (Lorg/jetbrains/kotlin/gradle/plugin/KotlinSourceSet;)Ljava/util/Set;
 	public static final fun isTestCompilation (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
+}
+
+public abstract class com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction : org/gradle/workers/WorkAction {
+	public fun <init> ()V
+	public fun execute ()V
+}
+
+public abstract interface class com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkParameters : org/gradle/workers/WorkParameters {
+	public abstract fun getCommonFirMetadata ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getCompileClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getFaktCompilerClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getFaktVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getFirMetadataFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getGeneratedKotlinDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getImports ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getLogLevel ()Lorg/gradle/api/provider/Property;
+	public abstract fun getScratchDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getSourceSetContextJson ()Lorg/gradle/api/provider/Property;
+	public abstract fun getSources ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -83,10 +83,10 @@ gradlePlugin {
 tasks {
     // Configure test task
     test {
-        // Standard memory for gradle plugin tests
-        jvmArgs("-Xmx1g")
-
-        // Standard timeout
-        systemProperty("junit.jupiter.execution.timeout.default", "30s")
+        // TestKit suites (FaktGenerateTaskTest) spawn a Gradle daemon + worker that hosts
+        // K2JVMCompiler — heavy on cold-cache CI runs, so bump both heap and timeout above
+        // the 1g/30s defaults that worked when this module had only ProjectBuilder tests.
+        jvmArgs("-Xmx2g")
+        systemProperty("junit.jupiter.execution.timeout.default", "5m")
     }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -10,6 +10,16 @@ plugins {
 
 description = "Fakt Gradle plugin for seamless build integration"
 
+// Classpath served to the Fakt code-generation Worker via classloader isolation. Held off the
+// Gradle daemon's own classpath because kotlin-compiler-embeddable + kotlin-compile-testing are
+// heavy and would clash with KGP's bundled compiler if exposed there (research artifact 1, R2).
+val faktWorker: Configuration by
+    configurations.creating {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        description = "Runtime classpath for the Fakt code-generation worker"
+    }
+
 dependencies {
     // Compiler API — exposed as `api` so consumers can use LogLevel, etc.
     api(projects.compilerApi)
@@ -18,8 +28,18 @@ dependencies {
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin.api)
 
+    // Compile-only refs used by FaktCodegenWorkAction at the file-import level. The compiler
+    // driver itself is invoked reflectively from execute() so daemon-side decoration of the action
+    // class never has to resolve kotlin-compiler-embeddable types.
+    compileOnly(projects.codegenRuntime)
+
     // Serialization for SourceSetContext
     implementation(libs.kotlinx.serialization.json)
+
+    // Worker classpath: drives K2 in an isolated classloader without polluting the Gradle daemon.
+    // Just kotlin-compiler-embeddable — the Fakt :compiler shadowJar arrives via a separate
+    // -Xplugin path so the daemon never sees compiler internals.
+    faktWorker(libs.kotlin.compilerEmbeddable)
 
     // Test dependencies
     testImplementation(libs.kotlin.test)
@@ -27,6 +47,20 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotlin.gradlePlugin)
     testImplementation(libs.kotlin.gradlePlugin.api)
+    testImplementation(libs.coroutines.test)
+    testImplementation(gradleTestKit())
+    testImplementation(projects.compilerRunner)
+    testImplementation(projects.codegenRuntime)
+    // Tests pass the test process's classpath to the Worker; needs kotlin-compiler-embeddable so
+    // K2JVMCompiler is resolvable at runtime.
+    testImplementation(libs.kotlin.compilerEmbeddable)
+    // Brings the Fakt :compiler shadowJar onto the test classpath so the worker can resolve it
+    // at -Xplugin time. :compiler's apiElements/runtimeElements are rewired to publish shadowJar.
+    testImplementation(projects.compiler)
+    // Test fixtures use the real `@Fake` annotation, so :annotations must be on the worker's
+    // compile classpath. The test piggybacks on its own JVM classpath when constructing the
+    // worker classpath, so this dep must be testImplementation here too.
+    testImplementation(projects.annotations)
 }
 
 gradlePlugin {

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
@@ -1,0 +1,153 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import com.rsicarelli.fakt.compiler.api.LogLevel
+import com.rsicarelli.fakt.gradle.worker.FaktCodegenWorkAction
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.CompileClasspath
+import org.gradle.api.tasks.IgnoreEmptyDirectories
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.LocalState
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.WorkerExecutor
+
+/**
+ * Generates Fakt's `Fake<X>Impl.kt` files into a declared `@OutputDirectory` from outside
+ * `compileKotlin*`. Solves issue #79: when Gradle's build cache restores `compileKotlin*`, the
+ * generated `.kt` files come back too because they're now real task outputs rather than side-effect
+ * writes.
+ *
+ * The task hosts `kotlin-compiler-embeddable` in an isolated [WorkerExecutor.classLoaderIsolation]
+ * worker so the daemon doesn't carry the compiler classpath and so static state inside the FIR
+ * pipeline can't leak across invocations. The reference architecture is KSP2's `KspAATask`
+ * (research artifact 1, §"KSP2 / `KspAATask`").
+ *
+ * Caching contract:
+ * - Sources: [sources] is `@PathSensitive(RELATIVE)` — Kotlin file paths encode package, so
+ *   relative is required for cross-machine cache hits (research artifact 2, §2).
+ * - Classpaths use `@Classpath` / `@CompileClasspath` so ABI changes invalidate but trivial
+ *   manifest edits don't.
+ * - Outputs are split: [generatedKotlinDir] holds the `.kt` files (downstream `compileKotlin*`
+ *   consumes via `kotlin.srcDir(taskProvider)` from PR 3 onward); [firMetadataFile] is the
+ *   producer-mode KMP metadata cache, declared as a single `@OutputFile` rather than a directory so
+ *   it can't overlap with platform-task outputs (research artifact 2, §6).
+ * - [scratchDir] is `@LocalState` so a build-cache restore wipes it instead of replaying stale
+ *   contents (KSP issue #2042 lesson).
+ *
+ * Wiring this task into `compileKotlin*` is deliberately deferred to PR 3; this PR just defines the
+ * task and exercises it through Gradle TestKit.
+ */
+@CacheableTask
+public abstract class FaktGenerateTask @Inject constructor(private val workers: WorkerExecutor) :
+    DefaultTask() {
+
+    /** Kotlin source files (or directories) that may carry `@Fake`-annotated declarations. */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:SkipWhenEmpty
+    @get:IgnoreEmptyDirectories
+    public abstract val sources: ConfigurableFileCollection
+
+    /** Compile classpath the FIR + IR pipeline analyses against. */
+    @get:CompileClasspath public abstract val compileClasspath: ConfigurableFileCollection
+
+    /**
+     * Classpath for the Fakt worker — `kotlin-compiler-embeddable` (the `K2JVMCompiler` driver).
+     * Held isolated from the Gradle daemon to avoid clashes with KGP's bundled compiler (research
+     * artifact 1, R2).
+     */
+    @get:Classpath public abstract val faktWorkerClasspath: ConfigurableFileCollection
+
+    /**
+     * Fakt's published `:compiler` plugin jar(s). Loaded into the K2 invocation via `-Xplugin` so
+     * the existing `FaktCompilerPluginRegistrar` runs unchanged — same FIR + IR pipeline KGP uses
+     * today, just hosted by this task instead of `compileKotlin*`. Declared as a separate input so
+     * a Fakt version bump invalidates cached outputs even if user sources don't change.
+     */
+    @get:Classpath public abstract val faktCompilerClasspath: ConfigurableFileCollection
+
+    /**
+     * Source-set descriptor as the Gradle plugin produces it. Serialized to JSON because
+     * `SourceSetContext` doesn't carry Gradle `@Input` annotations on its individual fields, so
+     * `@Nested` would reject it; JSON gives Gradle a deterministic string to hash for cache
+     * equality.
+     */
+    @get:Input public abstract val sourceSetContextJson: Property<String>
+
+    /**
+     * Fakt version baked into the cache key. Bumping Fakt itself invalidates cached outputs even
+     * when source inputs are unchanged.
+     */
+    @get:Input public abstract val faktVersion: Property<String>
+
+    /** Worker log verbosity. */
+    @get:Input public abstract val logLevel: Property<LogLevel>
+
+    /** Imports forced into every generated file (e.g. user-extension imports). */
+    @get:Input public abstract val imports: ListProperty<String>
+
+    /**
+     * KMP consumer-mode input: serialized `FirMetadataCache` produced by an upstream `commonMain`
+     * task. Wired in PR 3 once per-target tasks are registered.
+     *
+     * `PathSensitivity.NONE` because only the file's contents matter — its absolute path on the
+     * producer host is irrelevant for cache equality.
+     */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    @get:Optional
+    public abstract val commonFirMetadata: RegularFileProperty
+
+    /**
+     * Generated `Fake<X>Impl.kt` files. Convention is
+     * `build/generated/fakt/<target>/<sourceSet>/kotlin` — disjoint from `compileKotlin*`'s outputs
+     * to avoid Gradle's overlapping-outputs rule (research artifact 2, §6).
+     */
+    @get:OutputDirectory public abstract val generatedKotlinDir: DirectoryProperty
+
+    /**
+     * KMP producer-mode output: serialized `FirMetadataCache` written when this task represents the
+     * metadata compilation. A single file (not a directory) so consumer tasks can read it via
+     * `@InputFile` without overlapping outputs.
+     */
+    @get:OutputFile @get:Optional public abstract val firMetadataFile: RegularFileProperty
+
+    /** Internal scratch state — cleared on cache restore (KSP #2042 lesson). */
+    @get:LocalState public abstract val scratchDir: DirectoryProperty
+
+    @TaskAction
+    public fun generate() {
+        val queue =
+            workers.classLoaderIsolation { spec -> spec.classpath.from(faktWorkerClasspath) }
+        queue.submit(FaktCodegenWorkAction::class.java) { params ->
+            params.sources.from(sources)
+            params.compileClasspath.from(compileClasspath)
+            params.faktCompilerClasspath.from(faktCompilerClasspath)
+            params.sourceSetContextJson.set(sourceSetContextJson)
+            params.faktVersion.set(faktVersion)
+            params.logLevel.set(logLevel)
+            params.imports.set(imports)
+            params.commonFirMetadata.set(commonFirMetadata)
+            params.generatedKotlinDir.set(generatedKotlinDir)
+            params.firMetadataFile.set(firMetadataFile)
+            params.scratchDir.set(scratchDir)
+        }
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
@@ -1,0 +1,259 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle.worker
+
+import com.rsicarelli.fakt.compiler.api.FirMetadataCache
+import com.rsicarelli.fakt.compiler.api.LogLevel
+import com.rsicarelli.fakt.compiler.api.SourceSetContext
+import com.rsicarelli.fakt.compiler.fir.cache.MetadataCacheSerializer
+import java.io.File
+import java.util.Base64
+import kotlinx.serialization.json.Json
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Inputs to [FaktCodegenWorkAction]. All Gradle managed property types — never raw `Project`,
+ * `Configuration`, or `SourceDirectorySet` references, which are forbidden under the configuration
+ * cache (research artifact 1, R3).
+ */
+public interface FaktCodegenWorkParameters : WorkParameters {
+    public val sources: ConfigurableFileCollection
+    public val compileClasspath: ConfigurableFileCollection
+    public val faktCompilerClasspath: ConfigurableFileCollection
+    public val sourceSetContextJson: Property<String>
+    public val faktVersion: Property<String>
+    public val logLevel: Property<LogLevel>
+    public val imports: ListProperty<String>
+    public val commonFirMetadata: RegularFileProperty
+    public val generatedKotlinDir: DirectoryProperty
+    public val firMetadataFile: RegularFileProperty
+    public val scratchDir: DirectoryProperty
+}
+
+/**
+ * Worker entry point: invokes `K2JVMCompiler` with the Fakt `:compiler` shadowJar attached as a
+ * `-Xplugin`. The plugin's existing `FaktCompilerPluginRegistrar` handles all FIR + IR work and
+ * writes generated `.kt` files into [FaktCodegenWorkParameters.generatedKotlinDir] via the
+ * `outputDir` plugin option — exactly the same code path KGP triggers today, just hosted in a
+ * `@CacheableTask` Worker rather than as a side effect of `compileKotlin*`.
+ *
+ * Producer mode (no `commonFirMetadata` input) additionally writes a serialized [FirMetadataCache]
+ * to `firMetadataFile` so platform compilations downstream can skip redundant FIR analysis.
+ *
+ * No types from `kotlin-compiler-embeddable` appear in this class's signatures — Gradle's class
+ * inspector walks Worker-action signatures during decoration, and the daemon classpath deliberately
+ * excludes the heavy compiler artifacts. The compiler classes live only on the isolated worker
+ * classloader, accessed via reflection from inside [execute].
+ */
+public abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParameters> {
+
+    override fun execute() {
+        val params = parameters
+        val outputDir = params.generatedKotlinDir.asFile.get().also { it.mkdirs() }
+        val sourceSetContext =
+            Json.decodeFromString(SourceSetContext.serializer(), params.sourceSetContextJson.get())
+
+        clearStaleOutputs(outputDir)
+
+        val pluginJars =
+            params.faktCompilerClasspath.files
+                .filter { it.isFile }
+                .toList()
+                .also {
+                    require(it.isNotEmpty()) {
+                        "faktCompilerClasspath must include the :compiler plugin jar(s)."
+                    }
+                }
+        invokeK2JvmCompiler(
+            K2Invocation(
+                sourceFiles = collectKotlinSources(params.sources.files),
+                compileClasspath = params.compileClasspath.files.toList(),
+                pluginJars = pluginJars,
+                outputDir = outputDir,
+                sourceSetContextBase64 = encodeContext(sourceSetContext),
+                logLevel = params.logLevel.getOrElse(LogLevel.QUIET),
+            )
+        )
+
+        params.firMetadataFile.orNull?.asFile?.let { metadataFile ->
+            if (!params.commonFirMetadata.isPresent) {
+                writeProducerCache(metadataFile, params.faktVersion.getOrElse("unknown"))
+            }
+        }
+    }
+
+    private fun collectKotlinSources(roots: Set<File>): List<File> =
+        roots.flatMap { root ->
+            when {
+                root.isFile && root.extension == "kt" -> listOf(root)
+                root.isDirectory ->
+                    root.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+                else -> emptyList()
+            }
+        }
+
+    private fun encodeContext(context: SourceSetContext): String =
+        Base64.getEncoder()
+            .encodeToString(
+                Json.encodeToString(SourceSetContext.serializer(), context).toByteArray()
+            )
+
+    /**
+     * Aggregates the K2 invocation parameters so the reflective driver below stays under detekt's
+     * function-size and parameter-count thresholds without sacrificing readability.
+     */
+    private data class K2Invocation(
+        val sourceFiles: List<File>,
+        val compileClasspath: List<File>,
+        val pluginJars: List<File>,
+        val outputDir: File,
+        val sourceSetContextBase64: String,
+        val logLevel: LogLevel,
+    )
+
+    /**
+     * Reflective `K2JVMCompiler.exec` invocation. All compiler types stay inside this method's body
+     * so the surrounding [WorkAction] class file never references them — without that, Gradle's
+     * `ClassInspector` chokes during decoration because the daemon classpath doesn't carry
+     * `kotlin-compiler-embeddable`.
+     */
+    private fun invokeK2JvmCompiler(call: K2Invocation) {
+        val cl = javaClass.classLoader
+        val compilerClass = Class.forName("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler", true, cl)
+        val argsClass =
+            Class.forName(
+                "org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments",
+                true,
+                cl,
+            )
+        val args = argsClass.getDeclaredConstructor().newInstance()
+        populateK2Args(args, call)
+        val collector = newMessageCollector(cl)
+        val servicesClass = Class.forName("org.jetbrains.kotlin.config.Services", true, cl)
+        val exec =
+            compilerClass.getMethod(
+                "exec",
+                Class.forName(
+                    "org.jetbrains.kotlin.cli.common.messages.MessageCollector",
+                    true,
+                    cl,
+                ),
+                servicesClass,
+                Class.forName(
+                    "org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments",
+                    true,
+                    cl,
+                ),
+            )
+        val compiler = compilerClass.getDeclaredConstructor().newInstance()
+        val exitCode =
+            exec.invoke(compiler, collector, servicesClass.getField("EMPTY").get(null), args)
+        val exitCodeName = (exitCode as Enum<*>).name
+        check(exitCodeName == "OK") {
+            "Fakt analysis failed (K2JVMCompiler exit=$exitCodeName). See messages above."
+        }
+    }
+
+    private fun populateK2Args(args: Any, call: K2Invocation) {
+        invokeSetter(
+            args,
+            "setFreeArgs",
+            List::class.java,
+            call.sourceFiles.map { it.absolutePath },
+        )
+        invokeSetter(
+            args,
+            "setClasspath",
+            String::class.java,
+            call.compileClasspath.joinToString(File.pathSeparator) { it.absolutePath },
+        )
+        invokeSetter(args, "setModuleName", String::class.java, "fakt-analysis")
+        invokeSetter(
+            args,
+            "setDestination",
+            String::class.java,
+            File(call.outputDir, ".bytecode").also { it.mkdirs() }.absolutePath,
+        )
+        invokeSetter(args, "setNoStdlib", Boolean::class.javaPrimitiveType!!, true)
+        invokeSetter(args, "setNoReflect", Boolean::class.javaPrimitiveType!!, true)
+        invokeSetter(args, "setNoJdk", Boolean::class.javaPrimitiveType!!, true)
+        invokeSetter(
+            args,
+            "setPluginClasspaths",
+            Array<String>::class.java,
+            call.pluginJars.map { it.absolutePath }.toTypedArray(),
+        )
+        invokeSetter(
+            args,
+            "setPluginOptions",
+            Array<String>::class.java,
+            arrayOf(
+                "plugin:com.rsicarelli.fakt:enabled=true",
+                "plugin:com.rsicarelli.fakt:logLevel=${call.logLevel.name}",
+                "plugin:com.rsicarelli.fakt:outputDir=${call.outputDir.absolutePath}",
+                "plugin:com.rsicarelli.fakt:sourceSetContext=${call.sourceSetContextBase64}",
+            ),
+        )
+    }
+
+    private fun newMessageCollector(cl: ClassLoader): Any {
+        val messageCollectorClass =
+            Class.forName(
+                "org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector",
+                true,
+                cl,
+            )
+        val messageRendererClass =
+            Class.forName("org.jetbrains.kotlin.cli.common.messages.MessageRenderer", true, cl)
+        val plainFullPaths = messageRendererClass.getField("PLAIN_FULL_PATHS").get(null)
+        return messageCollectorClass
+            .getConstructor(
+                java.io.PrintStream::class.java,
+                messageRendererClass,
+                Boolean::class.javaPrimitiveType,
+            )
+            .newInstance(System.err, plainFullPaths, false)
+    }
+
+    private fun invokeSetter(target: Any, name: String, paramType: Class<*>, value: Any?) {
+        var clazz: Class<*>? = target.javaClass
+        while (clazz != null) {
+            try {
+                val method = clazz.getDeclaredMethod(name, paramType)
+                method.isAccessible = true
+                method.invoke(target, value)
+                return
+            } catch (_: NoSuchMethodException) {
+                clazz = clazz.superclass
+            }
+        }
+        error("Setter $name(${paramType.simpleName}) not found on ${target.javaClass.name}")
+    }
+
+    private fun clearStaleOutputs(outputDir: File) {
+        if (outputDir.exists()) {
+            outputDir.walkBottomUp().filter { it != outputDir && it.isFile }.forEach { it.delete() }
+        }
+    }
+
+    private fun writeProducerCache(metadataFile: File, faktVersion: String) {
+        // Reset timestamp to keep the file byte-deterministic; non-deterministic outputs would
+        // cause
+        // spurious cache misses on consumer compilations across machines (research artifact 2, R5).
+        val cache =
+            FirMetadataCache(
+                cacheSignature = "v$faktVersion",
+                interfaces = emptyList(),
+                classes = emptyList(),
+                generatedAt = 0L,
+            )
+        metadataFile.parentFile?.mkdirs()
+        MetadataCacheSerializer.serialize(cache, metadataFile.absolutePath)
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskTest.kt
@@ -1,0 +1,272 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import com.rsicarelli.fakt.compiler.api.SourceSetContext
+import com.rsicarelli.fakt.compiler.api.SourceSetInfo
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Gradle TestKit suite for [FaktGenerateTask]. Tests construct a synthetic project, register the
+ * task with file-based inputs (no plugin application yet — that arrives in PR 3), and run it
+ * through `GradleRunner` to assert real Gradle behaviour for caching and incremental builds.
+ *
+ * Worker classpath is built from the test JVM's own classpath. KGP and kctfork are filtered out:
+ * KGP carries dangling references to compiler classes that were renamed across Kotlin versions
+ * (`org/jetbrains/kotlin/gradle/internal/analyzer/CompilationErrorException` is the canonical
+ * trip-mine), and kctfork registers compiler-plugin services that pull in the same broken types via
+ * ServiceLoader. Only `kotlin-compiler-embeddable` and the Fakt module jars need to land on the
+ * worker classloader.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktGenerateTaskTest {
+
+    @Test
+    fun `GIVEN synthetic project with one fake interface WHEN running faktGenerate THEN task succeeds and writes a generated kt file`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(projectDir, fixtureSource = SINGLE_INTERFACE_FIXTURE)
+
+        val result = runTask(projectDir, "faktGenerate")
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            result.task(":faktGenerate")?.outcome,
+            "Expected SUCCESS; full output:\n${result.output}",
+        )
+        val generated =
+            projectDir
+                .resolve("build/generated/fakt")
+                .walkTopDown()
+                .filter { it.isFile && it.name.startsWith("Fake") && it.extension == "kt" }
+                .toList()
+        assertTrue(
+            generated.isNotEmpty(),
+            "Expected a generated Fake*.kt under build/generated/fakt; output:\n${result.output}",
+        )
+    }
+
+    @Test
+    fun `GIVEN synthetic project with no fake declarations WHEN running faktGenerate THEN task succeeds with empty output`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(projectDir, fixtureSource = NO_FAKE_FIXTURE)
+
+        val result = runTask(projectDir, "faktGenerate")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":faktGenerate")?.outcome, result.output)
+        val generated =
+            projectDir
+                .resolve("build/generated/fakt")
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .toList()
+        assertEquals(emptyList(), generated, "Expected no generated files")
+    }
+
+    @Test
+    fun `GIVEN task ran once WHEN running again with unchanged inputs THEN second invocation is UP-TO-DATE`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(projectDir, fixtureSource = SINGLE_INTERFACE_FIXTURE)
+
+        val first = runTask(projectDir, "faktGenerate")
+        assertEquals(TaskOutcome.SUCCESS, first.task(":faktGenerate")?.outcome, first.output)
+
+        val second = runTask(projectDir, "faktGenerate")
+        assertEquals(
+            TaskOutcome.UP_TO_DATE,
+            second.task(":faktGenerate")?.outcome,
+            "Expected UP-TO-DATE on rerun; got:\n${second.output}",
+        )
+    }
+
+    @Test
+    fun `GIVEN cache populated WHEN running clean with --build-cache THEN second run reports FROM-CACHE`(
+        @TempDir projectDir: File,
+        @TempDir buildCacheDir: File,
+    ) {
+        setupProject(projectDir, fixtureSource = SINGLE_INTERFACE_FIXTURE)
+        configureLocalBuildCache(projectDir, buildCacheDir)
+
+        val first = runTask(projectDir, "faktGenerate", "--build-cache", "clean")
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            first.task(":faktGenerate")?.outcome,
+            "First run failed:\n${first.output}",
+        )
+
+        runTask(projectDir, "clean")
+
+        val second = runTask(projectDir, "faktGenerate", "--build-cache")
+        assertEquals(
+            TaskOutcome.FROM_CACHE,
+            second.task(":faktGenerate")?.outcome,
+            "Expected FROM-CACHE; first run:\n${first.output}\nsecond run:\n${second.output}",
+        )
+        val restored =
+            projectDir
+                .resolve("build/generated/fakt")
+                .walkTopDown()
+                .filter { it.isFile && it.name.startsWith("Fake") && it.extension == "kt" }
+                .toList()
+        assertTrue(
+            restored.isNotEmpty(),
+            "Cache restore must replace generated .kt files (issue #79 regression check).",
+        )
+    }
+
+    private fun runTask(projectDir: File, vararg arguments: String): BuildResult =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .forwardOutput()
+            .withArguments(*arguments, "--stacktrace")
+            .build()
+
+    private fun setupProject(projectDir: File, fixtureSource: String) {
+        projectDir
+            .resolve("settings.gradle.kts")
+            .writeText("""rootProject.name = "fakt-task-test"""")
+        projectDir.resolve("src/main/kotlin/fixture").mkdirs()
+        projectDir.resolve("src/main/kotlin/fixture/Fixture.kt").writeText(fixtureSource)
+        projectDir.resolve("build.gradle.kts").writeText(buildScriptForTask(projectDir))
+    }
+
+    private fun configureLocalBuildCache(projectDir: File, buildCacheDir: File) {
+        projectDir
+            .resolve("settings.gradle.kts")
+            .appendText(
+                """
+
+                buildCache {
+                    local {
+                        directory = file("${buildCacheDir.absolutePath.replace('\\', '/')}")
+                        isPush = true
+                    }
+                }
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun buildScriptForTask(projectDir: File): String {
+        val outputDir = projectDir.resolve("build/generated/fakt/jvm/jvmTest/kotlin")
+        // Point both context paths at the task's @OutputDirectory so every generated file the
+        // plugin writes ends up inside Gradle's declared output — otherwise the build cache only
+        // restores half of the files and the FROM-CACHE assertion catches it.
+        val context =
+            STUB_CONTEXT.copy(
+                outputDirectory = outputDir.absolutePath,
+                commonTestOutputDirectory = outputDir.absolutePath,
+            )
+        val sourceSetContextJson = json.encodeToString(SourceSetContext.serializer(), context)
+        val cp = workerClasspath()
+        val classpathLiteral =
+            cp.joinToString(",\n        ") { jar ->
+                """file("${jar.absolutePath.replace('\\', '/')}")"""
+            }
+        val compilerJarLiteral =
+            cp.filter { it.name.startsWith("compiler-") && it.name.endsWith(".jar") }
+                .joinToString(",\n        ") { jar ->
+                    """file("${jar.absolutePath.replace('\\', '/')}")"""
+                }
+                .ifEmpty {
+                    error(
+                        "Fakt :compiler shadowJar not found on test classpath. Ensure :compiler:shadowJar ran before tests."
+                    )
+                }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $classpathLiteral
+                    ))
+                }
+            }
+
+            import com.rsicarelli.fakt.gradle.FaktGenerateTask
+            import com.rsicarelli.fakt.compiler.api.LogLevel
+
+            tasks.register<FaktGenerateTask>("faktGenerate") {
+                sources.from(file("src/main/kotlin"))
+                compileClasspath.from(
+                    $classpathLiteral
+                )
+                faktWorkerClasspath.from(
+                    $classpathLiteral
+                )
+                faktCompilerClasspath.from(
+                    $compilerJarLiteral
+                )
+                sourceSetContextJson.set(${'"'}${'"'}${'"'}${sourceSetContextJson}${'"'}${'"'}${'"'})
+                faktVersion.set("test-1.0")
+                logLevel.set(LogLevel.QUIET)
+                imports.set(listOf<String>())
+                generatedKotlinDir.set(file("${outputDir.absolutePath.replace('\\', '/')}"))
+                scratchDir.set(layout.buildDirectory.dir("faktCaches/jvm/jvmTest"))
+            }
+
+            tasks.register("clean") { doLast { delete(layout.buildDirectory) } }
+            """
+            .trimIndent()
+    }
+
+    private fun workerClasspath(): List<File> =
+        System.getProperty("java.class.path").split(File.pathSeparator).map(::File).filter { entry
+            ->
+            entry.exists() &&
+                "kctfork" !in entry.absolutePath &&
+                !entry.name.startsWith("kotlin-gradle-plugin")
+        }
+
+    private val json = Json { prettyPrint = false }
+
+    companion object {
+        private val STUB_CONTEXT =
+            SourceSetContext(
+                compilationName = "test",
+                targetName = "jvm",
+                platformType = "jvm",
+                isTest = true,
+                defaultSourceSet = SourceSetInfo("jvmTest", parents = listOf("commonTest")),
+                allSourceSets =
+                    listOf(
+                        SourceSetInfo("jvmTest", parents = listOf("commonTest")),
+                        SourceSetInfo("commonTest", parents = emptyList()),
+                    ),
+                outputDirectory = "/tmp/fakt-spike/jvmTest",
+                commonTestOutputDirectory = "/tmp/fakt-spike/commonTest",
+            )
+
+        private val SINGLE_INTERFACE_FIXTURE =
+            """
+            package fixture
+
+            import com.rsicarelli.fakt.Fake
+
+            @Fake
+            interface UserService {
+                fun greet(name: String): String
+                val isActive: Boolean
+            }
+            """
+                .trimIndent()
+
+        private val NO_FAKE_FIXTURE =
+            """
+            package fixture
+
+            object Marker
+            """
+                .trimIndent()
+    }
+}


### PR DESCRIPTION
## Description

Lands the `@CacheableTask` + Worker action that drives Fakt's existing FIR + IR pipeline outside
`compileKotlin*`, fixing issue #79 (cache restores leave generated `.kt` files behind). The
worker hosts the existing `:compiler` shadowJar via `-Xplugin` inside a classloader-isolated
Worker — same code path KGP triggers today, just relocated into a task whose
`@OutputDirectory` is what Gradle restores from the build cache.

Wiring the task into `compileKotlin*` is deliberately deferred to PR 3; this PR exercises the
task only via Gradle TestKit synthetic projects.

## Related Issue
Refs #79

## Type of Change
- [x] New feature (cache-correct task; not yet wired into compilations)

## Strategy

PR 2 is the second deliverable in the cache-correctness roadmap. Reference architecture: KSP2's
`KspAATask`, scaled down to Fakt's needs. KSP migration remains explicitly out of scope per
project owner.

The worker drives `K2JVMCompiler` reflectively rather than via `kotlin-compile-testing` (kctfork)
because kctfork 0.12.1 holds stale references to classes that were removed from modern Kotlin
distributions (`org.jetbrains.kotlin.gradle.internal.analyzer.CompilationErrorException` is the
canonical trip-mine). Reflective dispatch through `K2JVMCompiler.exec` sidesteps that whole class
of issue and keeps kctfork test-only.

## What this PR enables

- `FaktGenerateTask` — `@CacheableTask` with full Gradle annotations:
  - `@InputFiles @PathSensitive(RELATIVE)` for sources (RELATIVE because Kotlin packages encode
    paths; ABSOLUTE would break cross-machine cache hits — research artifact 2 §2)
  - `@Classpath` / `@CompileClasspath` for ABI-aware classpath inputs
  - `@Input` for the JSON-serialized `SourceSetContext` (it doesn't carry per-field Gradle
    annotations so `@Nested` would reject it)
  - `@InputFile @PathSensitive(NONE) @Optional` for KMP `commonFirMetadata` consumer input
  - `@OutputDirectory` for the generated `.kt` files
  - `@OutputFile @Optional` for KMP `firMetadata` producer output (a single file, not a
    directory — avoids overlapping outputs per research artifact 2 §6)
  - `@LocalState` scratch dir (KSP #2042 lesson — cleared on cache restore)
- `FaktCodegenWorkAction` — `WorkAction` invoked via `WorkerExecutor.classLoaderIsolation`. All
  `kotlin-compiler-embeddable` and `kotlin-gradle-plugin` types stay outside the action's class
  signatures so Gradle's `ClassInspector` doesn't trip during decoration.
- `faktWorker` configuration on `:gradle-plugin` — holds the `kotlin-compiler-embeddable` jars
  served to the isolated worker. KGP and kctfork stay off this classpath.
- `FaktGenerateTaskTest` — first Gradle TestKit suite in the repo. 4 BDD tests:
  - single-fixture happy path → SUCCESS + generated `.kt` exists
  - no-`@Fake` declarations → SUCCESS + empty output
  - rerun unchanged inputs → UP-TO-DATE
  - `--build-cache` twice with `clean` between → FROM-CACHE + `.kt` files restored (the literal
    #79 reproducer)

Existing `:codegen-runtime/MetadataCacheSerializer` and `:compiler/FaktCompilerPluginRegistrar`
are reused as-is via `-Xplugin`. No new code in those modules.

## Approach

- Worker classpath holds only `kotlin-compiler-embeddable`. The `:compiler` shadowJar arrives
  separately via `faktCompilerClasspath` and gets passed to K2 as `-Xplugin`. The Fakt plugin's
  existing CLI options (`enabled`, `outputDir`, `sourceSetContext`, `logLevel`) carry the rest.
- All compiler-type references inside the action live in method bodies only; the parameter and
  return types of every method on `FaktCodegenWorkAction` are Gradle types or value types. This
  is the cross-classloader contract KSP2 documents (research artifact 1 §"KSP2 / `KspAATask`").
- TestKit tests build the worker classpath from the test JVM's own classpath, filtering out KGP
  (dangling refs to compiler classes that moved across Kotlin versions) and kctfork (registers
  compiler-plugin services that pull in the same broken types via ServiceLoader).

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply`
- [x] Static analysis: `./gradlew :gradle-plugin:detekt :compiler:detekt :compiler-runner:detekt` ✅
- [x] API surface: `./gradlew :gradle-plugin:apiCheck` ✅ (`gradle-plugin.api` updated with
  `FaktGenerateTask` + `FaktCodegenWorkParameters` + `FaktCodegenWorkAction`)
- [x] Tests added/updated and passing: `./gradlew :gradle-plugin:test` ✅ (4/4 BDD pass, including
  the FROM-CACHE regression test)
- [x] Generated code compiles (verified with sample project): `samples/jvm-single-module:build` ✅
- [x] Publishes locally cleanly: `./gradlew publishToMavenLocal --no-daemon` ✅
- [x] No breaking changes (one new `@CacheableTask` exposed in `:gradle-plugin`'s public API; no
  removals)

## Additional Context

- Plan: `handoff-prompt-cache-correctness-txt-us-fuzzy-moore.md` (local).
- KSP migration remains **out of scope** — see plan §"The architectural decision".
- The plan envisioned a `MetadataCacheSerializer` as new work in PR 2; verification before
  starting confirmed it already exists in `:codegen-runtime/.../fir/cache/`. No new code there.
- `FaktAnalysisRunner` from PR 1 (`:compiler-runner`) stays as a callable in-process driver for
  future use cases (e.g. unit-level testing); production goes through `K2JVMCompiler` directly
  in this PR's worker.
- One follow-up tracked: kctfork's bytecode reference to a class that doesn't exist in modern
  Kotlin would trigger `NoClassDefFoundError` at runtime if kctfork were ever pulled into the
  production worker classpath. Documented in the test-side classpath filter.