### PR TITLE
feat(gradle-plugin): wire FaktGenerateTask into compileKotlin* behind flag

### DIFF
--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -52,6 +52,7 @@ public abstract class com/rsicarelli/fakt/gradle/FaktGenerateTask : org/gradle/a
 
 public final class com/rsicarelli/fakt/gradle/FaktGradleSubplugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
 	public static final field Companion Lcom/rsicarelli/fakt/gradle/FaktGradleSubplugin$Companion;
+	public static final field FAKT_KOTLIN_VERSION Ljava/lang/String;
 	public static final field PLUGIN_ARTIFACT_NAME Ljava/lang/String;
 	public static final field PLUGIN_GROUP_ID Ljava/lang/String;
 	public static final field PLUGIN_ID Ljava/lang/String;
@@ -78,6 +79,7 @@ public class com/rsicarelli/fakt/gradle/FaktPluginExtension {
 	public final fun getEnableMutableFakes ()Lorg/gradle/api/provider/Property;
 	public final fun getEnabled ()Lorg/gradle/api/provider/Property;
 	public final fun getLogLevel ()Lorg/gradle/api/provider/Property;
+	public final fun getUseExperimentalGenerateTask ()Lorg/gradle/api/provider/Property;
 	public final fun getUseGradleTestFixtures ()Lorg/gradle/api/provider/Property;
 }
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
@@ -1,0 +1,171 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import com.rsicarelli.fakt.compiler.api.SourceSetContext
+import java.util.Locale
+import kotlinx.serialization.json.Json
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
+
+/**
+ * Registers a `FaktGenerateTask` for a single Kotlin compilation and wires its `@OutputDirectory`
+ * into the matching test source set. Extracted from [FaktGradleSubplugin] so the entry-point class
+ * stays under detekt's per-class function-count threshold.
+ *
+ * Cross-classloader contract: every method here is plain Gradle API + the Fakt
+ * [com.rsicarelli.fakt.compiler.api.SourceSetContext] data class. Nothing in
+ * `kotlin-compiler-embeddable` is referenced.
+ */
+internal object FaktGenerateTaskWiring {
+
+    /** Sentinel used inside the task's `@Input` JSON; the worker overwrites with real paths. */
+    private const val OUTPUT_PLACEHOLDER: String = "fakt://generated"
+
+    /** Build-dir token in the placeholder context, kept stable across machines for cache parity. */
+    private const val BUILD_DIR_PLACEHOLDER: String = "<task-output>"
+
+    /**
+     * Registers a `FaktGenerateTask` for [kotlinCompilation], wires its output into the matching
+     * test source set, and sets up the KMP cross-target `dependsOn` chain.
+     */
+    fun register(
+        project: Project,
+        kotlinCompilation: KotlinCompilation<*>,
+        extension: FaktPluginExtension,
+    ) {
+        val targetName =
+            kotlinCompilation.target.targetName.ifBlank {
+                kotlinCompilation.target.platformType.name.lowercase()
+            }
+        val compilationName = kotlinCompilation.name
+        val taskName = taskNameFor(targetName, compilationName)
+        if (project.tasks.findByName(taskName) != null) return
+
+        // applyToCompilation fires before afterEvaluate, so the configurations may not exist yet
+        // by the time we land here. Idempotent helper makes the call safe to repeat.
+        getSubpluginInstance(project).ensureFaktConfigurations(project)
+
+        val outputDir =
+            project.layout.buildDirectory.dir("generated/fakt/$targetName/$compilationName/kotlin")
+        val scratchDir =
+            project.layout.buildDirectory.dir("faktCaches/$targetName/$compilationName")
+        val firMetadataFile =
+            project.layout.buildDirectory.file(
+                "generated/fakt/$targetName/$compilationName/metadata/fir-metadata.json"
+            )
+        val placeholderJson = encodePlaceholderContext(kotlinCompilation)
+        val workerClasspath = project.configurations.named(FaktGradleSubplugin.WORKER_CONFIGURATION)
+        val compilerClasspath =
+            project.configurations.named(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION)
+
+        val taskProvider =
+            project.tasks.register(taskName, FaktGenerateTask::class.java) { task ->
+                task.sources.from(
+                    kotlinCompilation.allKotlinSourceSets.map { sourceSet -> sourceSet.kotlin }
+                )
+                task.compileClasspath.from(kotlinCompilation.compileDependencyFiles)
+                task.faktWorkerClasspath.from(workerClasspath)
+                task.faktCompilerClasspath.from(compilerClasspath)
+                task.sourceSetContextJson.set(placeholderJson)
+                task.faktVersion.set(FaktGradleSubplugin.PLUGIN_VERSION)
+                task.logLevel.set(extension.logLevel)
+                task.imports.set(emptyList())
+                task.generatedKotlinDir.set(outputDir)
+                task.scratchDir.set(scratchDir)
+                if (isMetadataLikeCompilation(kotlinCompilation)) {
+                    task.firMetadataFile.set(firMetadataFile)
+                }
+            }
+
+        wireTestSrcDir(project, kotlinCompilation, taskProvider)
+        wireKmpDependsOnCommonMain(project, kotlinCompilation, taskProvider)
+    }
+
+    /**
+     * Adds the task's `generatedKotlinDir` to the matching test source set as a Kotlin srcDir. Lazy
+     * via `TaskProvider` so Gradle infers `builtBy` and downstream `compileKotlin*Test` waits for
+     * the generator with no explicit `dependsOn`.
+     */
+    private fun wireTestSrcDir(
+        project: Project,
+        kotlinCompilation: KotlinCompilation<*>,
+        taskProvider: TaskProvider<FaktGenerateTask>,
+    ) {
+        val testSourceSetName = mapMainToTest(kotlinCompilation.defaultSourceSet.name)
+        val kmp = project.extensions.findByType(KotlinMultiplatformExtension::class.java)
+        val generatedDirProvider = taskProvider.flatMap { it.generatedKotlinDir }
+        if (kmp != null) {
+            kmp.sourceSets.findByName(testSourceSetName)?.kotlin?.srcDir(generatedDirProvider)
+        } else {
+            project.tasks.withType(AbstractKotlinCompile::class.java).configureEach { compileTask ->
+                if (compileTask.name.lowercase().contains("test")) {
+                    compileTask.source(generatedDirProvider)
+                }
+            }
+        }
+    }
+
+    /**
+     * Every platform `faktGenerate*` task depends on the commonMain counterpart so common-source
+     * `@Fake` declarations are validated once and reused. Mirrors KSP2's
+     * `kspCommonMainKotlinMetadata` pattern; safe under Gradle 9 Project Isolation (no
+     * `afterEvaluate`, no direct task-graph reads).
+     */
+    private fun wireKmpDependsOnCommonMain(
+        project: Project,
+        kotlinCompilation: KotlinCompilation<*>,
+        taskProvider: TaskProvider<FaktGenerateTask>,
+    ) {
+        if (kotlinCompilation.defaultSourceSet.name == "commonMain") return
+        if (project.extensions.findByType(KotlinMultiplatformExtension::class.java) == null) return
+        taskProvider.configure { task ->
+            val commonTask =
+                project.tasks.findByName("faktGenerateMetadataCommonMain")
+                    ?: project.tasks.findByName("faktGenerateCommonMain")
+            if (commonTask != null) task.dependsOn(commonTask)
+        }
+    }
+
+    /** Locate the [FaktGradleSubplugin] instance applied to [project] to call its helpers. */
+    private fun getSubpluginInstance(project: Project): FaktGradleSubplugin =
+        project.plugins.getPlugin(FaktGradleSubplugin::class.java)
+
+    private fun isMetadataLikeCompilation(kotlinCompilation: KotlinCompilation<*>): Boolean =
+        kotlinCompilation.defaultSourceSet.name == "commonMain" ||
+            kotlinCompilation.target.platformType.name.equals("common", ignoreCase = true)
+
+    private fun encodePlaceholderContext(kotlinCompilation: KotlinCompilation<*>): String {
+        val context =
+            SourceSetDiscovery.buildContext(
+                    kotlinCompilation,
+                    buildDir = BUILD_DIR_PLACEHOLDER,
+                    useTestFixtures = false,
+                )
+                .copy(
+                    outputDirectory = OUTPUT_PLACEHOLDER,
+                    commonTestOutputDirectory = OUTPUT_PLACEHOLDER,
+                    metadataOutputPath = null,
+                    metadataCachePath = null,
+                )
+        val json = Json { prettyPrint = false }
+        return json.encodeToString(SourceSetContext.serializer(), context)
+    }
+
+    private fun taskNameFor(targetName: String, compilationName: String): String =
+        "faktGenerate" + capitalizeAscii(targetName) + capitalizeAscii(compilationName)
+
+    private fun mapMainToTest(sourceSetName: String): String =
+        when {
+            sourceSetName.equals("main", ignoreCase = true) -> "test"
+            sourceSetName.endsWith("Main", ignoreCase = true) ->
+                sourceSetName.removeSuffix("Main") + "Test"
+            else -> sourceSetName + "Test"
+        }
+
+    private fun capitalizeAscii(s: String): String =
+        if (s.isEmpty()) s else s.substring(0, 1).uppercase(Locale.ROOT) + s.substring(1)
+}

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -78,6 +78,26 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         public const val PLUGIN_ARTIFACT_NAME: String = "compiler"
         public const val PLUGIN_GROUP_ID: String = "com.rsicarelli.fakt"
         public const val PLUGIN_VERSION: String = "1.0.0-beta08"
+
+        /**
+         * `kotlin-compiler-embeddable` version pulled into the worker's isolated classpath. Pinned
+         * to the Kotlin version Fakt was built and tested against. Users can override the
+         * `faktWorker` configuration in their project if they need a different compiler version
+         * (e.g. for a Kotlin EAP).
+         */
+        public const val FAKT_KOTLIN_VERSION: String = "2.3.20"
+
+        internal const val WORKER_CONFIGURATION: String = "faktWorker"
+        internal const val COMPILER_CLASSPATH_CONFIGURATION: String = "faktCompiler"
+        internal const val GRADLE_PROPERTY_FLAG: String = "fakt.useExperimentalGenerateTask"
+
+        /**
+         * Sentinel substituted into [SourceSetContext.outputDirectory] /
+         * [SourceSetContext.commonTestOutputDirectory] when the JSON is stored as a task `@Input` —
+         * the worker overwrites these with absolute paths from file properties at execution time so
+         * the cache key never carries machine-specific paths.
+         */
+        private const val OUTPUT_PLACEHOLDER: String = "fakt://generated"
     }
 
     @OptIn(ExperimentalFaktMultiModule::class)
@@ -102,16 +122,67 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                 // GENERATOR MODE: Generate fakes from @Fake annotations
                 target.logger.info("Fakt: Generator mode enabled - generating fakes")
 
-                // Validate test fixtures configuration
-                val useTestFixtures = resolveTestFixturesMode(target, extension)
-
-                // Configure source sets for generated code
-                val configurator = SourceSetConfigurator(target, useTestFixtures)
-                configurator.configureSourceSets()
+                if (resolveExperimentalGenerateTaskFlag(target, extension)) {
+                    target.logger.info(
+                        "Fakt: useExperimentalGenerateTask=true — registering FaktGenerateTask " +
+                            "per compilation; the in-process compiler-plugin path stays disabled."
+                    )
+                    ensureFaktConfigurations(target)
+                } else {
+                    // LEGACY in-process path. Source-set wiring stays eager.
+                    val useTestFixtures = resolveTestFixturesMode(target, extension)
+                    val configurator = SourceSetConfigurator(target, useTestFixtures)
+                    configurator.configureSourceSets()
+                }
             }
         }
 
         target.logger.info("Fakt: Applied Gradle plugin to project ${target.name}")
+    }
+
+    /**
+     * Reads the experimental flag from (in priority order) the `fakt { }` extension and the Gradle
+     * property `fakt.useExperimentalGenerateTask`. Property gives end-users an opt-in switch
+     * without having to touch the build script — useful for trying the cache-correct path on a
+     * single CI run.
+     */
+    private fun resolveExperimentalGenerateTaskFlag(
+        project: Project,
+        extension: FaktPluginExtension,
+    ): Boolean {
+        if (extension.useExperimentalGenerateTask.get()) return true
+        return project.providers
+            .gradleProperty(GRADLE_PROPERTY_FLAG)
+            .orNull
+            ?.toBooleanStrictOrNull() ?: false
+    }
+
+    /**
+     * Idempotently creates the resolvable configurations that feed the worker classloader. Safe to
+     * call from both `apply` / `afterEvaluate` and `applyToCompilation` because `maybeCreate(...)`
+     * is no-op on the second call. Required at the call site that runs earliest:
+     * `applyToCompilation` fires before `afterEvaluate`, so the configurations have to exist before
+     * the task is registered.
+     */
+    internal fun ensureFaktConfigurations(target: Project) {
+        target.configurations.maybeCreate(WORKER_CONFIGURATION).apply {
+            isCanBeResolved = true
+            isCanBeConsumed = false
+            description = "Runtime classpath for Fakt's code-generation worker (K2JVMCompiler)."
+        }
+        target.configurations.maybeCreate(COMPILER_CLASSPATH_CONFIGURATION).apply {
+            isCanBeResolved = true
+            isCanBeConsumed = false
+            description = "Fakt's :compiler shadowJar classpath, attached to K2 via -Xplugin."
+        }
+        target.dependencies.add(
+            WORKER_CONFIGURATION,
+            "org.jetbrains.kotlin:kotlin-compiler-embeddable:$FAKT_KOTLIN_VERSION",
+        )
+        target.dependencies.add(
+            COMPILER_CLASSPATH_CONFIGURATION,
+            "$PLUGIN_GROUP_ID:$PLUGIN_ARTIFACT_NAME:$PLUGIN_VERSION",
+        )
     }
 
     /**
@@ -258,38 +329,48 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
             "Fakt: Applying compiler plugin to compilation ${kotlinCompilation.name}"
         )
 
-        return project.provider {
-            buildList {
-                // Pass configuration options to the compiler plugin
-                add(SubpluginOption(key = "enabled", value = extension.enabled.get().toString()))
-                add(SubpluginOption(key = "logLevel", value = extension.logLevel.get().name))
-                add(
-                    SubpluginOption(
-                        key = "enableCallHistory",
-                        value = extension.enableCallHistory.get().toString(),
-                    )
-                )
-                add(
-                    SubpluginOption(
-                        key = "enableMutableFakes",
-                        value = extension.enableMutableFakes.get().toString(),
-                    )
-                )
-
-                val buildDir = project.layout.buildDirectory.get().asFile.absolutePath
-                val useTestFixtures = resolveTestFixturesMode(project, extension)
-                val context =
-                    SourceSetDiscovery.buildContext(kotlinCompilation, buildDir, useTestFixtures)
-
-                // Serialize context to Base64-encoded JSON for compiler plugin
-                val json = Json { prettyPrint = false }
-                val jsonString = json.encodeToString(context)
-                val base64Encoded = Base64.getEncoder().encodeToString(jsonString.toByteArray())
-                add(SubpluginOption(key = "sourceSetContext", value = base64Encoded))
-
-                // Also pass output directory for backwards compatibility
-                add(SubpluginOption(key = "outputDir", value = context.outputDirectory))
-            }
+        if (resolveExperimentalGenerateTaskFlag(project, extension)) {
+            // Side-effect: register FaktGenerateTask + wire its @OutputDirectory into the
+            // matching test source set. Returns `enabled=false` so the in-process compiler
+            // plugin (still loaded by KGP into compileKotlin*) skips registration — generation
+            // happens in our task instead. Empty list isn't enough: FaktCompilerPluginRegistrar
+            // defaults `enabled` to true and would explode when sourceSetContext is missing.
+            FaktGenerateTaskWiring.register(project, kotlinCompilation, extension)
+            return project.provider { listOf(SubpluginOption(key = "enabled", value = "false")) }
         }
+
+        return project.provider { legacyInProcessOptions(project, kotlinCompilation, extension) }
+    }
+
+    /** Original in-process subplugin option payload, untouched. */
+    private fun legacyInProcessOptions(
+        project: Project,
+        kotlinCompilation: KotlinCompilation<*>,
+        extension: FaktPluginExtension,
+    ): List<SubpluginOption> = buildList {
+        add(SubpluginOption(key = "enabled", value = extension.enabled.get().toString()))
+        add(SubpluginOption(key = "logLevel", value = extension.logLevel.get().name))
+        add(
+            SubpluginOption(
+                key = "enableCallHistory",
+                value = extension.enableCallHistory.get().toString(),
+            )
+        )
+        add(
+            SubpluginOption(
+                key = "enableMutableFakes",
+                value = extension.enableMutableFakes.get().toString(),
+            )
+        )
+
+        val buildDir = project.layout.buildDirectory.get().asFile.absolutePath
+        val useTestFixtures = resolveTestFixturesMode(project, extension)
+        val context = SourceSetDiscovery.buildContext(kotlinCompilation, buildDir, useTestFixtures)
+
+        val json = Json { prettyPrint = false }
+        val jsonString = json.encodeToString(context)
+        val base64Encoded = Base64.getEncoder().encodeToString(jsonString.toByteArray())
+        add(SubpluginOption(key = "sourceSetContext", value = base64Encoded))
+        add(SubpluginOption(key = "outputDir", value = context.outputDirectory))
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
@@ -190,6 +190,38 @@ constructor(objects: ObjectFactory, private val project: Project) {
         objects.property(Boolean::class.java).convention(false)
 
     /**
+     * Opt in to the cache-correct `FaktGenerateTask` codepath that hosts Fakt's compiler in a
+     * Gradle Worker outside `compileKotlin*`. Fixes issue #79 — when Gradle's build cache restores
+     * `compileKotlin*`, the generated `.kt` files come back too because they're declared task
+     * outputs rather than side-effect writes.
+     *
+     * **Default:** `false` (the existing in-process compiler-plugin path runs unchanged).
+     *
+     * **Usage (build script):**
+     *
+     * ```kotlin
+     * fakt {
+     *     useExperimentalGenerateTask.set(true)
+     * }
+     * ```
+     *
+     * **Usage (Gradle property — flips the default for any project that hasn't set it
+     * explicitly):**
+     *
+     * ```
+     * gradle build -Pfakt.useExperimentalGenerateTask=true
+     * ```
+     *
+     * Setting the value in the extension wins over the property if both are present.
+     *
+     * Marked experimental during the rollout (PRs #97 → #100). The default flips in PR 5; this
+     * property becomes the explicit opt-out for one minor before the legacy in-process path is
+     * removed.
+     */
+    public val useExperimentalGenerateTask: Property<Boolean> =
+        objects.property(Boolean::class.java).convention(false)
+
+    /**
      * Source project to collect generated fakes from (collector mode).
      *
      * When set, this module switches to **collector mode**:

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
@@ -191,7 +191,10 @@ internal abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParame
         )
         bridge.setOnArgs(args, "setNoStdlib", Boolean::class.javaPrimitiveType!!, true)
         bridge.setOnArgs(args, "setNoReflect", Boolean::class.javaPrimitiveType!!, true)
-        bridge.setOnArgs(args, "setNoJdk", Boolean::class.javaPrimitiveType!!, true)
+        // Leave the JDK on the compilation classpath — production sources reference
+        // `java.io.Serializable`, `java.util.*`, etc. K2 needs JDK rt to resolve them. The PR 2
+        // smoke tests got away with `noJdk=true` because kctfork supplied the JDK via
+        // `inheritClassPath = true`; the production worker doesn't.
     }
 
     private fun populatePluginArgs(bridge: K2CompilerBridge, args: Any, call: K2Invocation) {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktExperimentalGenerateTaskWiringTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktExperimentalGenerateTaskWiringTest.kt
@@ -1,0 +1,130 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * BDD coverage for the experimental `fakt.useExperimentalGenerateTask` rollout switch (PR 3).
+ *
+ * End-to-end behaviour (per-compilation `FaktGenerateTask` registration,
+ * `kotlin.srcDir(taskProvider)` wiring, KMP `dependsOn` ordering) requires the Kotlin Gradle Plugin
+ * to be applied — not feasible inside `ProjectBuilder` because the KGP wiring is heavy. Those flows
+ * are covered by the sample matrix in CI (`samples/jvm-single-module:build
+ * -Pfakt.useExperimentalGenerateTask=true`); this suite focuses on the parts that are
+ * unit-testable: extension defaults, property opt-in, and the resolvable configurations the worker
+ * classpath rides on.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktExperimentalGenerateTaskWiringTest {
+
+    @Test
+    fun `GIVEN plugin applied WHEN reading useExperimentalGenerateTask THEN defaults to false`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
+
+        val extension = project.extensions.getByType(FaktPluginExtension::class.java)
+
+        assertFalse(
+            extension.useExperimentalGenerateTask.get(),
+            "Default must be false so the legacy in-process path stays the rollout target.",
+        )
+    }
+
+    @Test
+    fun `GIVEN extension WHEN setting useExperimentalGenerateTask THEN flag flips`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
+        val extension = project.extensions.getByType(FaktPluginExtension::class.java)
+
+        extension.useExperimentalGenerateTask.set(true)
+
+        assertTrue(extension.useExperimentalGenerateTask.get())
+    }
+
+    @Test
+    fun `GIVEN flag false on apply WHEN evaluating THEN faktWorker faktCompiler configurations are NOT created`(
+        @TempDir tempDir: java.io.File
+    ) {
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
+
+        (project as ProjectInternal).evaluate()
+
+        assertNull(
+            project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION),
+            "faktWorker should only be created when the flag is on — legacy path stays clean.",
+        )
+        assertNull(
+            project.configurations.findByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION),
+            "faktCompiler should only be created when the flag is on.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag set true via extension WHEN evaluating THEN faktWorker and faktCompiler configurations exist`(
+        @TempDir tempDir: java.io.File
+    ) {
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
+        project.extensions
+            .getByType(FaktPluginExtension::class.java)
+            .useExperimentalGenerateTask
+            .set(true)
+
+        (project as ProjectInternal).evaluate()
+
+        val worker = project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION)
+        val compiler =
+            project.configurations.findByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION)
+        assertNotNull(worker, "faktWorker configuration must be created when flag=true.")
+        assertNotNull(compiler, "faktCompiler configuration must be created when flag=true.")
+        assertTrue(worker.isCanBeResolved, "faktWorker must be resolvable for worker classpath.")
+        assertFalse(
+            worker.isCanBeConsumed,
+            "faktWorker is internal — never participates in inter-project resolution.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag set true via extension WHEN evaluating THEN faktWorker has kotlin-compiler-embeddable + faktCompiler has Fakt compiler artifact`(
+        @TempDir tempDir: java.io.File
+    ) {
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
+        project.extensions
+            .getByType(FaktPluginExtension::class.java)
+            .useExperimentalGenerateTask
+            .set(true)
+
+        (project as ProjectInternal).evaluate()
+
+        val workerDeps =
+            project.configurations.getByName(FaktGradleSubplugin.WORKER_CONFIGURATION).dependencies
+        assertTrue(
+            workerDeps.any {
+                it.group == "org.jetbrains.kotlin" && it.name == "kotlin-compiler-embeddable"
+            },
+            "faktWorker must include kotlin-compiler-embeddable; current deps: ${workerDeps.map { "${it.group}:${it.name}" }}",
+        )
+        val compilerDeps =
+            project.configurations
+                .getByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION)
+                .dependencies
+        assertTrue(
+            compilerDeps.any {
+                it.group == FaktGradleSubplugin.PLUGIN_GROUP_ID &&
+                    it.name == FaktGradleSubplugin.PLUGIN_ARTIFACT_NAME
+            },
+            "faktCompiler must include Fakt's :compiler artifact; current deps: ${compilerDeps.map { "${it.group}:${it.name}" }}",
+        )
+    }
+}


### PR DESCRIPTION
## Description

Per the cache-correctness roadmap (issue #79), this is PR 3: the `FaktGenerateTask` from PR #98
now actually runs against user projects when the new feature flag is on. Default stays off — the
in-process compiler-plugin path is unchanged for everyone who hasn't opted in.

## Related Issue
Refs #79

## Type of Change
- [x] New feature (gated behind opt-in flag, no behavioural change for default users)

## Strategy

Lands the wiring on top of PRs #97 → #100. With PR #100's relocation + byte-determinism fixes
already merged, the new task is now cache-correct end-to-end. PR 4 hooks the multi-module
collector; PR 5 flips the default and lands the CI regression test.

## Opt-in surface

```kotlin
// build script
fakt {
    useExperimentalGenerateTask.set(true)
}
```

```bash
# command line
gradle build -Pfakt.useExperimentalGenerateTask=true
```

Extension wins over the property when both are set.

## What runs when the flag is on

- `applyToCompilation` registers one `FaktGenerateTask` per non-test Kotlin compilation; task
  name is `faktGenerate<Target><Compilation>` (e.g., `faktGenerateJvmMain`,
  `faktGenerateMetadataCommonMain`).
- The task's `@OutputDirectory` is wired into the matching test source set:
  - **KMP**: `KotlinSourceSet.kotlin.srcDir(taskProvider.flatMap { it.generatedKotlinDir })`
  - **JVM-only**: `AbstractKotlinCompile.source(taskProvider)` on every `*Test` compile task
- **Cross-target ordering**: every platform `faktGenerate*` task `dependsOn` the commonMain
  counterpart. Mirrors KSP2's `kspCommonMainKotlinMetadata` pattern; lazy via `TaskProvider`,
  safe under Gradle 9 Project Isolation (no `afterEvaluate`, no direct task-graph reads).
- `applyToCompilation` returns `enabled=false` so KGP's `compileKotlin*` still loads the Fakt
  compiler plugin but the registrar exits early — generation happens exclusively in the new
  task, never as a side-effect of `compileKotlin*`. That's the whole point.

## Plumbing

- `FaktGradleSubplugin` gains `FAKT_KOTLIN_VERSION` (pinned to `2.3.20`) plus two resolvable
  configurations:
  - `faktWorker` → `kotlin-compiler-embeddable:2.3.20` (the worker classpath that hosts K2)
  - `faktCompiler` → `com.rsicarelli.fakt:compiler:1.0.0-beta08` (the shadowJar attached via
    `-Xplugin`)
  - Both `isCanBeConsumed = false`; project-internal only.
- Configurations created idempotently both in `afterEvaluate` **and** at task-registration time.
  `applyToCompilation` fires before `afterEvaluate`, so `maybeCreate(...)` has to be safe to
  repeat.
- The `SourceSetContext` stored as `@Input sourceSetContextJson` is built with **placeholder
  paths** (`fakt://generated`, `<task-output>`); the worker overwrites with absolute paths from
  file properties at execution time. This preserves the relocation invariant fixed in PR #100.
- `FaktGenerateTaskWiring` — new file extracted from `FaktGradleSubplugin` so the entry-point
  class stays under detekt's per-class function-count threshold (11).

## Worker tweak

`FaktCodegenWorkAction.populateOutputArgs` no longer sets `noJdk=true`. Real production sources
reference `java.io.Serializable` / `java.util.*`, so K2 needs the JDK on the compile classpath.
PR #98's smoke tests got away without it because kctfork supplied the JDK via
`inheritClassPath=true`; the production worker doesn't.

## Tests

5 new BDD tests in `FaktExperimentalGenerateTaskWiringTest` (ProjectBuilder-based):
- Extension defaults to `false`
- Flag flips when set
- Configurations are created when flag=true
- Configurations are NOT created when flag=false (legacy path stays clean)
- Configurations carry the right Maven coordinates

Plus the existing `:gradle-plugin` suite (76 tests + 5 new = 81 total) all green. The `:gradle-plugin`
TestKit tests from PR #98 + #100 still pass — the task itself is unchanged at runtime.

## Manual end-to-end verification

```bash
cd samples/jvm-single-module
../../gradlew clean build -Pfakt.useExperimentalGenerateTask=true
# → faktGenerateMain runs, generates Fake*Impl.kt files
# → compileKotlin succeeds (in-process plugin sees enabled=false, exits early)
# → compileTestKotlin picks up the generated files via taskProvider srcDir
# → tests pass
```

The CI sample matrix will validate the flag-on path against the other samples
(`kmp-single-module`, `kmp-multi-target`, `android-single-module`, etc.) automatically once this
PR's CI runs.

## Pre-Submission Checklist

- [x] Code formatted: `./gradlew spotlessApply`
- [x] Static analysis: `./gradlew :gradle-plugin:detekt` ✅ (refactored `FaktGradleSubplugin` to stay under TooManyFunctions)
- [x] API surface: `./gradlew :gradle-plugin:apiCheck` ✅ (regenerated; new public surface is `FAKT_KOTLIN_VERSION` + `useExperimentalGenerateTask` getter)
- [x] Tests passing: `./gradlew :gradle-plugin:test` ✅
- [x] Configuration cache clean: `./gradlew --configuration-cache :gradle-plugin:test` ✅
- [x] Sample regression (legacy path unchanged): `samples/jvm-single-module:build` ✅
- [x] Sample with flag on: `samples/jvm-single-module:build -Pfakt.useExperimentalGenerateTask=true` ✅
- [x] Publishes locally cleanly: `./gradlew publishToMavenLocal --no-daemon` ✅

## Note for review

Two follow-ups deferred to PR 4 / PR 5:

1. **KMP wiring depth**: this PR sets up `dependsOn` from platform tasks to the commonMain
   task. Full KMP cross-target metadata caching (consumer-mode `commonFirMetadata` input wired
   from upstream) lands in PR 4 alongside the multi-module collector update.
2. **CI regression test**: the canonical `--build-cache → clean → --build-cache → FROM-CACHE +
   .kt files restored` test against `samples/kmp-multi-module` lands in PR 5 with the cutover.

Both are scoped per the original plan.