### PR TITLE
feat(gradle-plugin): cache-correct multi-module collector (#79)

### DIFF
--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -8,6 +8,7 @@ public abstract class com/rsicarelli/fakt/gradle/FakeCollectorTask : org/gradle/
 	public abstract fun getAvailableSourceSets ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getDestinationDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getLogLevel ()Lorg/gradle/api/provider/Property;
+	public abstract fun getSourceFakeRoots ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getSourceGeneratedDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getSourceProjectPath ()Lorg/gradle/api/provider/Property;
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTask.kt
@@ -8,13 +8,19 @@ import com.rsicarelli.fakt.gradle.FakeCollectorTask.Companion.registerForKmpProj
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -50,8 +56,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
  *
  * @see ExperimentalFaktMultiModule
  */
+@CacheableTask
 @ExperimentalFaktMultiModule
 public abstract class FakeCollectorTask : DefaultTask() {
+
     /**
      * The path to the source project that generates fakes. Configuration cache compatible (stores
      * path, not Project object).
@@ -61,9 +69,32 @@ public abstract class FakeCollectorTask : DefaultTask() {
     /**
      * The directory where the source project generates fakes. Typically: build/generated/fakt/
      * Optional because not all source sets may have generated fakes.
+     *
+     * Used only by the legacy in-process compiler-plugin path, which writes fakes as a side effect
+     * of `compileKotlin*` and therefore cannot be declared as a Gradle task input. Under the
+     * cache-correct path (`useExperimentalGenerateTask=true`), [sourceFakeRoots] supersedes this
+     * property — see the doc on that field.
      */
     @get:Internal // Not using @InputDirectory to allow missing directories
     public abstract val sourceGeneratedDir: DirectoryProperty
+
+    /**
+     * Aggregated `generatedKotlinDir` outputs of every [FaktGenerateTask] registered on the source
+     * project. Wired through `ConfigurableFileCollection.from(Provider)` so Gradle carries the
+     * `builtBy` chain automatically — no `dependsOn(matching { name == "compile…" })` needed, which
+     * is the regression class tracked as KSP #2442 / #2595 / #2623 (R4 in the cache-correctness
+     * roadmap).
+     *
+     * Declared `@InputFiles` rather than `@Internal` so the collector's own cache key fingerprints
+     * the source `.kt` payload — the cache-correct path is end-to-end, not just at the producer.
+     *
+     * Empty when the source project still uses the legacy in-process compiler-plugin path, in which
+     * case the action falls back to polling [sourceGeneratedDir].
+     */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:IgnoreEmptyDirectories
+    public abstract val sourceFakeRoots: ConfigurableFileCollection
 
     /**
      * The destination directory where collected fakes will be placed. Typically:
@@ -94,17 +125,138 @@ public abstract class FakeCollectorTask : DefaultTask() {
         group = "fakt"
         description = "Collects generated fakes from source project"
 
-        // Task depends on source project's compilation to ensure fakes are generated first
-        // Note: Dependency will be configured in registerForKmpProject to avoid configuration cache
-        // issues
+        // Caching is only correct when sources arrive through `sourceFakeRoots`. Under the legacy
+        // in-process path the action polls `sourceGeneratedDir` at execution time — not declared as
+        // an input, so any "cache hit" would be a stale-output bug. Once PR 5 retires the legacy
+        // path this gate can disappear and the task becomes unconditionally cacheable.
+        @Suppress("LeakingThis")
+        outputs.cacheIf("sourceFakeRoots wired (cache-correct path)") { !sourceFakeRoots.isEmpty }
     }
 
     @TaskAction
     public fun collectFakes() {
         val startTime = System.nanoTime()
         val faktLogger = GradleFaktLogger(logger, logLevel.get())
-        val faktRootDir = sourceGeneratedDir.asFile.get()
 
+        val taskProviderRoots = sourceFakeRoots.files.filter { it.isDirectory }
+        val sourceSetNames = availableSourceSets.getOrElse(mutableSetOf())
+        // `destinationDir` is the routing root — platform subdirs (`jvmMain/kotlin/...`) are
+        // written directly under it so Gradle's build cache fingerprints every routed file as part
+        // of this task's @OutputDirectory. Earlier code aliased it as a `_placeholder` dir and
+        // wrote one level up, which silently disabled cache restore for the collector (PR 4).
+        val destinationBaseDir = destinationDir.asFile.get()
+        val platformStats = mutableMapOf<String, Int>()
+        val totalCollected =
+            if (taskProviderRoots.isNotEmpty()) {
+                collectFromTaskProviderRoots(
+                    roots = taskProviderRoots,
+                    destinationBaseDir = destinationBaseDir,
+                    availableSourceSets = sourceSetNames,
+                    faktLogger = faktLogger,
+                    platformStats = platformStats,
+                )
+            } else {
+                collectFromLegacySourceDir(
+                    destinationBaseDir = destinationBaseDir,
+                    availableSourceSets = sourceSetNames,
+                    faktLogger = faktLogger,
+                    platformStats = platformStats,
+                )
+            } ?: return
+
+        val totalDuration = System.nanoTime() - startTime
+        val srcProjectName = sourceProjectPath.orNull?.substringAfterLast(":") ?: "unknown"
+
+        faktLogger.info(
+            "✅ $totalCollected fake(s) collected from $srcProjectName | " +
+                TimeFormatter.format(totalDuration)
+        )
+        platformStats.forEach { (platform, count) ->
+            faktLogger.info("  ├─ $platform: $count file(s)")
+        }
+    }
+
+    /**
+     * Cache-correct path. Each entry of [roots] is a [FaktGenerateTask.generatedKotlinDir] — a
+     * package-structured Kotlin source root. Files are routed by package-derived platform detection
+     * exactly like the legacy path; the only difference is that we never poll a source-project
+     * directory at execution time, so Gradle's build cache fingerprints the actual inputs.
+     */
+    private fun collectFromTaskProviderRoots(
+        roots: List<File>,
+        destinationBaseDir: File,
+        availableSourceSets: Set<String>,
+        faktLogger: GradleFaktLogger,
+        platformStats: MutableMap<String, Int>,
+    ): Int {
+        var totalCollected = 0
+        roots.forEach { root ->
+            val rootStartTime = System.nanoTime()
+            val result =
+                collectWithPlatformDetection(
+                    sourceDir = root,
+                    destinationBaseDir = destinationBaseDir,
+                    availableSourceSets = availableSourceSets,
+                    faktLogger = faktLogger,
+                )
+            totalCollected += result.collectedCount
+            result.platformDistribution.forEach { (platform, count) ->
+                platformStats[platform] = (platformStats[platform] ?: 0) + count
+            }
+            faktLogger.debug(
+                "Collected ${result.collectedCount} fake(s) from ${root.name} " +
+                    "(${TimeFormatter.format(System.nanoTime() - rootStartTime)})"
+            )
+        }
+        return totalCollected
+    }
+
+    /**
+     * Legacy in-process path. Walks the source project's `build/generated/fakt/` directory at
+     * execution time. Returns `null` when nothing is found (caller short-circuits the summary log).
+     */
+    private fun collectFromLegacySourceDir(
+        destinationBaseDir: File,
+        availableSourceSets: Set<String>,
+        faktLogger: GradleFaktLogger,
+        platformStats: MutableMap<String, Int>,
+    ): Int? {
+        val faktRootDir = sourceGeneratedDir.asFile.get()
+        val sourceSetDirs =
+            faktRootDir.takeIf { it.exists() }?.listFiles()?.filter { it.isDirectory }.orEmpty()
+        if (sourceSetDirs.isEmpty()) {
+            warnLegacyEmpty(faktRootDir, faktLogger)
+            return null
+        }
+
+        var totalCollected = 0
+        sourceSetDirs.forEach { sourceSetDir ->
+            val kotlinDir = sourceSetDir.resolve("kotlin")
+            if (!kotlinDir.exists() || !kotlinDir.isDirectory) {
+                faktLogger.debug("Skipping ${sourceSetDir.name} (no kotlin directory)")
+                return@forEach
+            }
+            val sourceSetStartTime = System.nanoTime()
+            val result =
+                collectWithPlatformDetection(
+                    sourceDir = kotlinDir,
+                    destinationBaseDir = destinationBaseDir,
+                    availableSourceSets = availableSourceSets,
+                    faktLogger = faktLogger,
+                )
+            totalCollected += result.collectedCount
+            result.platformDistribution.forEach { (platform, count) ->
+                platformStats[platform] = (platformStats[platform] ?: 0) + count
+            }
+            faktLogger.debug(
+                "Collected ${result.collectedCount} fake(s) from ${sourceSetDir.name} " +
+                    "(${TimeFormatter.format(System.nanoTime() - sourceSetStartTime)})"
+            )
+        }
+        return totalCollected
+    }
+
+    private fun warnLegacyEmpty(faktRootDir: File, faktLogger: GradleFaktLogger) {
         if (!faktRootDir.exists()) {
             val srcProjectName = sourceProjectPath.orNull?.substringAfterLast(":") ?: "unknown"
             faktLogger.warn(
@@ -112,72 +264,8 @@ public abstract class FakeCollectorTask : DefaultTask() {
                     "Verify that source module has @Fake annotated interfaces, " +
                     "or remove this collector module if not needed."
             )
-            return
-        }
-
-        // Auto-discover all source set directories (commonTest, jvmTest, etc.)
-        val sourceSetDirs = faktRootDir.listFiles()?.filter { it.isDirectory } ?: emptyList()
-
-        if (sourceSetDirs.isEmpty()) {
+        } else {
             faktLogger.warn("No generated fakes found in $faktRootDir")
-            return
-        }
-
-        // Destination base directory (parent of platform-specific dirs)
-        // destinationDir points to a placeholder, we use its parent
-        val destinationBaseDir = destinationDir.asFile.get().parentFile
-
-        var totalCollected = 0
-        val platformStats = mutableMapOf<String, Int>()
-
-        // Process each source set directory with platform detection
-        sourceSetDirs.forEach { sourceSetDir ->
-            val sourceSetStartTime = System.nanoTime()
-            val kotlinDir = sourceSetDir.resolve("kotlin")
-
-            if (!kotlinDir.exists() || !kotlinDir.isDirectory) {
-                faktLogger.debug("Skipping ${sourceSetDir.name} (no kotlin directory)")
-                return@forEach
-            }
-
-            // Use platform detection for this source set (with available source sets if configured)
-            val sourceSetNames = availableSourceSets.getOrElse(mutableSetOf())
-            val result =
-                collectWithPlatformDetection(
-                    sourceDir = kotlinDir,
-                    destinationBaseDir = destinationBaseDir,
-                    availableSourceSets = sourceSetNames,
-                    faktLogger = faktLogger,
-                )
-
-            totalCollected += result.collectedCount
-            result.platformDistribution.forEach { (platform, count) ->
-                platformStats[platform] = (platformStats[platform] ?: 0) + count
-            }
-
-            val sourceSetDuration = System.nanoTime() - sourceSetStartTime
-            faktLogger.debug(
-                "Collected ${result.collectedCount} fake(s) from ${sourceSetDir.name} " +
-                    "(${TimeFormatter.format(sourceSetDuration)})"
-            )
-        }
-
-        // Calculate total duration
-        val totalDuration = System.nanoTime() - startTime
-        val srcProjectName = sourceProjectPath.orNull?.substringAfterLast(":") ?: "unknown"
-
-        // Log summary (INFO level)
-        faktLogger.info(
-            "✅ $totalCollected fake(s) collected from $srcProjectName | ${
-                TimeFormatter.format(
-                    totalDuration
-                )
-            }"
-        )
-
-        // Log platform distribution (INFO level)
-        platformStats.forEach { (platform, count) ->
-            faktLogger.info("  ├─ $platform: $count file(s)")
         }
     }
 
@@ -392,15 +480,28 @@ public abstract class FakeCollectorTask : DefaultTask() {
                 project.tasks.register(taskName, FakeCollectorTask::class.java) {
                     it.sourceProjectPath.set(srcProject.path)
 
-                    // Point to root fakt directory - task will auto-discover subdirectories
+                    // Cache-correct path. `from(Provider)` carries `builtBy` automatically so the
+                    // collector waits for every `FaktGenerateTask` on the source project — no
+                    // string-matched `dependsOn(matching { ... })`, which is the regression class
+                    // tracked as KSP #2442 / #2595 / #2623. Empty under the legacy in-process path.
+                    it.sourceFakeRoots.from(
+                        srcProject.tasks.withType(FaktGenerateTask::class.java).map { generateTask
+                            ->
+                            generateTask.generatedKotlinDir
+                        }
+                    )
+
+                    // Legacy fallback: source project still on the in-process compiler-plugin path.
+                    // Polled at execution time; not a declared input. PR 5 removes this path.
                     it.sourceGeneratedDir.set(
                         srcProject.layout.buildDirectory.dir("generated/fakt")
                     )
 
-                    // Base directory for platform-specific collection
-                    // Task will create subdirectories: commonMain/, jvmMain/, etc.
+                    // Routing root for platform-specific collection. The action creates
+                    // subdirectories `commonMain/kotlin`, `jvmMain/kotlin`, … directly under this
+                    // dir, so the build cache fingerprints every routed file (PR 4).
                     it.destinationDir.set(
-                        project.layout.buildDirectory.dir("generated/collected-fakes/_placeholder")
+                        project.layout.buildDirectory.dir("generated/collected-fakes")
                     )
 
                     // Configure available source sets for dynamic platform detection
@@ -410,8 +511,10 @@ public abstract class FakeCollectorTask : DefaultTask() {
                     // Wire logLevel from extension for consistent telemetry
                     it.logLevel.set(extension.logLevel)
 
-                    // Add dependency on source project's MAIN compilation tasks only
-                    // Avoid test compilations to prevent circular dependencies
+                    // Legacy ordering fallback for the in-process path. When the source uses
+                    // `FaktGenerateTask` instead, `sourceFakeRoots` above already pulls the
+                    // implicit dependency through `builtBy`, so this matcher is redundant but
+                    // harmless.
                     it.dependsOn(
                         srcProject.tasks.matching { task ->
                             task.name.contains("compile", ignoreCase = true) &&
@@ -434,10 +537,7 @@ public abstract class FakeCollectorTask : DefaultTask() {
                 .configureEach { sourceSet ->
                     val platformDir =
                         task.map {
-                            it.destinationDir.asFile
-                                .get()
-                                .parentFile // up from _placeholder
-                                .resolve("${sourceSet.name}/kotlin")
+                            it.destinationDir.asFile.get().resolve("${sourceSet.name}/kotlin")
                         }
                     sourceSet.kotlin.srcDir(platformDir)
 
@@ -495,21 +595,28 @@ public abstract class FakeCollectorTask : DefaultTask() {
                 project.tasks.register("collectFakes", FakeCollectorTask::class.java) {
                     it.sourceProjectPath.set(srcProject.path)
 
-                    // Point to root fakt directory - task will auto-discover subdirectories
+                    // Cache-correct path; see KDoc on the KMP variant for the rationale.
+                    it.sourceFakeRoots.from(
+                        srcProject.tasks.withType(FaktGenerateTask::class.java).map { generateTask
+                            ->
+                            generateTask.generatedKotlinDir
+                        }
+                    )
+
+                    // Legacy fallback (in-process compiler plugin). Removed in PR 5.
                     it.sourceGeneratedDir.set(
                         srcProject.layout.buildDirectory.dir("generated/fakt")
                     )
 
+                    // Routing root; mirrors the KMP variant — see KDoc on the KMP setup.
                     it.destinationDir.set(
-                        project.layout.buildDirectory.dir("generated/collected-fakes/kotlin")
+                        project.layout.buildDirectory.dir("generated/collected-fakes")
                     )
 
                     // Wire logLevel from extension for consistent telemetry
                     it.logLevel.set(extension.logLevel)
 
-                    // Add dependency on source project's MAIN compilation tasks only
-                    // Avoid test compilations to prevent circular dependencies
-                    // (test compilations may depend on -fakes modules)
+                    // Legacy ordering fallback; redundant once `sourceFakeRoots` is wired.
                     it.dependsOn(
                         srcProject.tasks.matching { task ->
                             task.name.contains("compile", ignoreCase = true) &&
@@ -518,8 +625,11 @@ public abstract class FakeCollectorTask : DefaultTask() {
                     )
                 }
 
-            // Register collected fakes directory as source and wire task dependencies
-            val collectedDir = project.layout.buildDirectory.dir("generated/collected-fakes/kotlin")
+            // Single-platform projects never supply `availableSourceSets`, so the action routes
+            // every fake to the `commonMain` fallback subdir. Source set wiring follows that
+            // convention.
+            val collectedDir =
+                task.map { it.destinationDir.asFile.get().resolve("commonMain/kotlin") }
 
             // === JVM Projects ===
             project.plugins.withId("org.jetbrains.kotlin.jvm") {

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -122,15 +122,22 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                 // GENERATOR MODE: Generate fakes from @Fake annotations
                 target.logger.info("Fakt: Generator mode enabled - generating fakes")
 
-                if (resolveExperimentalGenerateTaskFlag(target, extension)) {
+                val isKmp =
+                    target.extensions.findByType(
+                        org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java
+                    ) != null
+                val useTestFixtures = resolveTestFixturesMode(target, extension)
+                if (resolveExperimentalGenerateTaskFlag(target, extension) && !isKmp) {
                     target.logger.info(
                         "Fakt: useExperimentalGenerateTask=true — registering FaktGenerateTask " +
                             "per compilation; the in-process compiler-plugin path stays disabled."
                     )
                     ensureFaktConfigurations(target)
                 } else {
-                    // LEGACY in-process path. Source-set wiring stays eager.
-                    val useTestFixtures = resolveTestFixturesMode(target, extension)
+                    // Legacy in-process path. Also taken when the flag is on but the project is
+                    // KMP — the cache-correct worker only drives K2JVMCompiler today, so a
+                    // metadata/native producer is a deferred follow-up. Until then, KMP falls
+                    // through to the legacy wiring unchanged.
                     val configurator = SourceSetConfigurator(target, useTestFixtures)
                     configurator.configureSourceSets()
                 }
@@ -329,7 +336,10 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
             "Fakt: Applying compiler plugin to compilation ${kotlinCompilation.name}"
         )
 
-        if (resolveExperimentalGenerateTaskFlag(project, extension)) {
+        if (
+            resolveExperimentalGenerateTaskFlag(project, extension) &&
+                isCacheCorrectPathSupported(kotlinCompilation)
+        ) {
             // Side-effect: register FaktGenerateTask + wire its @OutputDirectory into the
             // matching test source set. Returns `enabled=false` so the in-process compiler
             // plugin (still loaded by KGP into compileKotlin*) skips registration — generation
@@ -340,6 +350,29 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         }
 
         return project.provider { legacyInProcessOptions(project, kotlinCompilation, extension) }
+    }
+
+    /**
+     * The cache-correct worker drives `K2JVMCompiler` reflectively, so it can only analyse JVM
+     * bytecode-producing compilations. Two further constraints narrow the scope:
+     * 1. **Platform.** KMP metadata, Native, JS and Wasm compilations need their own K2 drivers
+     *    (`K2MetadataCompiler` et al.) plus matching common/native stdlib classpaths — deferred
+     *    follow-up.
+     * 2. **KMP source-set inheritance.** Even on a JVM target inside a KMP project, the `jvmMain`
+     *    compilation's analysis source set is `jvmMain + commonMain` (KGP attaches parent source
+     *    sets). The task would generate fakes for `commonMain` `@Fake` interfaces too, conflicting
+     *    with the legacy in-process path that handles `compileKotlinMetadata`. Disabling the legacy
+     *    path entirely under the flag isn't safe yet (no `K2MetadataCompiler` producer) — so for
+     *    now KMP projects stay on legacy across the board.
+     *
+     * Pure JVM Gradle projects (no `KotlinMultiplatformExtension`) take the cache-correct path.
+     */
+    private fun isCacheCorrectPathSupported(kotlinCompilation: KotlinCompilation<*>): Boolean {
+        val platform = kotlinCompilation.target.platformType.name.lowercase()
+        if (platform != "jvm" && platform != "androidjvm") return false
+        return kotlinCompilation.project.extensions.findByType(
+            org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java
+        ) == null
     }
 
     /** Original in-process subplugin option payload, untouched. */

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTaskCacheTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTaskCacheTest.kt
@@ -1,0 +1,183 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Gradle TestKit suite for [FakeCollectorTask]'s cache-correctness contract (PR 4 of the issue #79
+ * roadmap). Tests register the collector against a stand-in `Sync` task that mimics the
+ * `FaktGenerateTask.generatedKotlinDir` output — this keeps the test free of the K2 worker
+ * classpath setup the producer suite needs, while still proving:
+ * 1. The collector's `sourceFakeRoots` `@InputFiles` produces a stable build-cache key, so a clean
+ *    rebuild against a populated `--build-cache` reports `FROM-CACHE`. This is the canonical
+ *    issue #79 regression at collector level.
+ * 2. Wiring `sourceFakeRoots.from(taskProvider.map { it.outputDir })` carries the implicit
+ *    `builtBy` chain, so requesting `:collectFakes` alone implicitly runs the producer.
+ *
+ * Legacy in-process path is intentionally not exercised here — see [FakeCollectorTaskTest] for the
+ * action-level coverage of that fallback.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FakeCollectorTaskCacheTest {
+
+    @Test
+    fun `GIVEN populated cache WHEN running clean rebuild with --build-cache THEN collector reports FROM-CACHE`(
+        @TempDir projectDir: File,
+        @TempDir buildCacheDir: File,
+    ) {
+        setupProject(projectDir)
+        configureLocalBuildCache(projectDir, buildCacheDir)
+
+        val first = runTask(projectDir, "collectFakes", "--build-cache")
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            first.task(":collectFakes")?.outcome,
+            "First run failed:\n${first.output}",
+        )
+        assertTrue(
+            projectDir
+                .resolve("build/collected/jvmMain/kotlin/api/jvm/FakeJvmServiceImpl.kt")
+                .exists(),
+            "First run must produce the routed fake.",
+        )
+
+        runTask(projectDir, "clean")
+
+        val second = runTask(projectDir, "collectFakes", "--build-cache")
+        assertEquals(
+            TaskOutcome.FROM_CACHE,
+            second.task(":collectFakes")?.outcome,
+            "Expected FROM-CACHE on second run — collector is not cache-correct.\n" +
+                "first run:\n${first.output}\nsecond run:\n${second.output}",
+        )
+        assertTrue(
+            projectDir
+                .resolve("build/collected/jvmMain/kotlin/api/jvm/FakeJvmServiceImpl.kt")
+                .exists(),
+            "Cache restore must replace the collected output (issue #79 regression at collector).",
+        )
+    }
+
+    @Test
+    fun `GIVEN collector wired via TaskProvider chain WHEN running collector alone THEN producer is triggered implicitly`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(projectDir)
+
+        val result = runTask(projectDir, "collectFakes")
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            result.task(":fakeProducer")?.outcome,
+            "Producer must run before collector via the builtBy chain on sourceFakeRoots.\n${result.output}",
+        )
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            result.task(":collectFakes")?.outcome,
+            "Collector itself failed:\n${result.output}",
+        )
+    }
+
+    private fun runTask(projectDir: File, vararg arguments: String): BuildResult =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .forwardOutput()
+            .withArguments(*arguments, "--stacktrace")
+            .build()
+
+    private fun setupProject(projectDir: File) {
+        projectDir
+            .resolve("settings.gradle.kts")
+            .writeText("""rootProject.name = "fakt-collector-test"""")
+        // TestKit daemons share state across tests; cap heap explicitly to avoid Metaspace bloat
+        // when the suite runs alongside FaktGenerateTaskTest in the same fork.
+        projectDir
+            .resolve("gradle.properties")
+            .writeText("org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1024m\n")
+        // Pre-staged fixture mimicking what FaktGenerateTask would write under
+        // build/generated/fakt/<target>/<compilation>/kotlin
+        val fixture = projectDir.resolve("fixture/api/jvm/FakeJvmServiceImpl.kt")
+        fixture.parentFile.mkdirs()
+        fixture.writeText("package api.jvm\nclass FakeJvmServiceImpl")
+        projectDir.resolve("build.gradle.kts").writeText(buildScript())
+    }
+
+    private fun configureLocalBuildCache(projectDir: File, buildCacheDir: File) {
+        projectDir
+            .resolve("settings.gradle.kts")
+            .appendText(
+                """
+
+                buildCache {
+                    local {
+                        directory = file("${buildCacheDir.absolutePath.replace('\\', '/')}")
+                        isPush = true
+                    }
+                }
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun buildScript(): String {
+        val cp = workerClasspath()
+        val classpathLiteral =
+            cp.joinToString(",\n        ") { jar ->
+                """file("${jar.absolutePath.replace('\\', '/')}")"""
+            }
+        return """
+            @file:OptIn(com.rsicarelli.fakt.gradle.ExperimentalFaktMultiModule::class)
+
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $classpathLiteral
+                    ))
+                }
+            }
+
+            import com.rsicarelli.fakt.gradle.FakeCollectorTask
+            import com.rsicarelli.fakt.compiler.api.LogLevel
+
+            // Stand-in for FaktGenerateTask. Output mirrors generatedKotlinDir's layout: a package-
+            // structured Kotlin source root.
+            val fakeProducer = tasks.register<Sync>("fakeProducer") {
+                from("fixture")
+                into(layout.buildDirectory.dir("generated/fakt/jvm/main/kotlin"))
+            }
+
+            tasks.register<FakeCollectorTask>("collectFakes") {
+                sourceProjectPath.set(":fixture")
+                sourceFakeRoots.from(fakeProducer.map { it.destinationDir })
+                destinationDir.set(layout.buildDirectory.dir("collected"))
+                availableSourceSets.set(setOf("commonMain", "jvmMain"))
+                logLevel.set(LogLevel.QUIET)
+            }
+
+            tasks.register("clean") { doLast { delete(layout.buildDirectory) } }
+            """
+            .trimIndent()
+    }
+
+    /**
+     * Plugin-under-test classpath, minus kctfork and kotlin-gradle-plugin — both pull stale
+     * compiler internals and would crash the TestKit daemon's classloader. Mirrors the filter on
+     * [FaktGenerateTaskTest.workerClasspath].
+     */
+    private fun workerClasspath(): List<File> =
+        System.getProperty("java.class.path").split(File.pathSeparator).map(::File).filter { entry
+            ->
+            entry.exists() &&
+                "kctfork" !in entry.absolutePath &&
+                !entry.name.startsWith("kotlin-gradle-plugin")
+        }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTaskTest.kt
@@ -4,9 +4,16 @@
 
 package com.rsicarelli.fakt.gradle
 
+import com.rsicarelli.fakt.compiler.api.LogLevel
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
@@ -539,6 +546,111 @@ class FakeCollectorTaskTest {
             "commonMain",
             sourceSet,
             "Should fallback to commonMain when no available source sets provided",
+        )
+    }
+
+    @Test
+    fun `GIVEN sourceFakeRoots populated WHEN action runs THEN routes each fake to its platform source set`(
+        @TempDir tempDir: File
+    ) {
+        val jvmRoot =
+            tempDir.resolve("src-build/generated/fakt/jvm/main/kotlin").also { it.mkdirs() }
+        jvmRoot
+            .resolve("api/jvm")
+            .apply { mkdirs() }
+            .resolve("FakeJvmServiceImpl.kt")
+            .writeText("package api.jvm\nclass FakeJvmServiceImpl")
+        val commonRoot =
+            tempDir.resolve("src-build/generated/fakt/metadata/commonMain/kotlin").also {
+                it.mkdirs()
+            }
+        commonRoot
+            .resolve("api/shared")
+            .apply { mkdirs() }
+            .resolve("FakeNetworkServiceImpl.kt")
+            .writeText("package api.shared\nclass FakeNetworkServiceImpl")
+
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        val destDir = tempDir.resolve("dest")
+        val task =
+            project.tasks
+                .register("collectFakes", FakeCollectorTask::class.java) {
+                    it.sourceProjectPath.set(":src")
+                    it.sourceFakeRoots.from(jvmRoot, commonRoot)
+                    it.sourceGeneratedDir.set(tempDir.resolve("does-not-exist"))
+                    it.destinationDir.set(destDir)
+                    it.availableSourceSets.set(setOf("commonMain", "jvmMain"))
+                    it.logLevel.set(LogLevel.QUIET)
+                }
+                .get()
+
+        task.collectFakes()
+
+        assertTrue(
+            destDir.resolve("jvmMain/kotlin/api/jvm/FakeJvmServiceImpl.kt").exists(),
+            "Expected JVM fake routed to jvmMain via task-provider path.",
+        )
+        assertTrue(
+            destDir.resolve("commonMain/kotlin/api/shared/FakeNetworkServiceImpl.kt").exists(),
+            "Expected common fake routed to commonMain via task-provider path.",
+        )
+    }
+
+    @Test
+    fun `GIVEN empty sourceFakeRoots WHEN action runs THEN falls back to legacy sourceGeneratedDir polling`(
+        @TempDir tempDir: File
+    ) {
+        val legacyRoot = tempDir.resolve("src-build/generated/fakt").also { it.mkdirs() }
+        legacyRoot
+            .resolve("commonTest/kotlin/api/legacy")
+            .apply { mkdirs() }
+            .resolve("FakeLegacyServiceImpl.kt")
+            .writeText("package api.legacy\nclass FakeLegacyServiceImpl")
+
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        val destDir = tempDir.resolve("dest")
+        val task =
+            project.tasks
+                .register("collectFakes", FakeCollectorTask::class.java) {
+                    it.sourceProjectPath.set(":src")
+                    it.sourceGeneratedDir.set(legacyRoot)
+                    it.destinationDir.set(destDir)
+                    it.availableSourceSets.set(setOf("commonMain", "jvmMain"))
+                    it.logLevel.set(LogLevel.QUIET)
+                }
+                .get()
+
+        task.collectFakes()
+
+        assertTrue(
+            destDir.resolve("commonMain/kotlin/api/legacy/FakeLegacyServiceImpl.kt").exists(),
+            "Legacy polling path must keep working when sourceFakeRoots is empty.",
+        )
+        assertFalse(
+            destDir.resolve("jvmMain/kotlin/api/legacy/FakeLegacyServiceImpl.kt").exists(),
+            "Unambiguously-common package must not leak into jvmMain.",
+        )
+    }
+
+    @Test
+    fun `GIVEN sourceFakeRoots property WHEN inspected via reflection THEN carries InputFiles + relative path sensitivity`() {
+        val getter = FakeCollectorTask::class.java.methods.first { it.name == "getSourceFakeRoots" }
+
+        val inputFiles = getter.getAnnotation(InputFiles::class.java)
+        assertNotNull(
+            inputFiles,
+            "sourceFakeRoots must be @InputFiles so the collector's cache key fingerprints source .kt payloads.",
+        )
+
+        val pathSensitivity = getter.getAnnotation(PathSensitive::class.java)
+        assertNotNull(
+            pathSensitivity,
+            "sourceFakeRoots must declare @PathSensitive for relocatability.",
+        )
+        assertEquals(
+            PathSensitivity.RELATIVE,
+            pathSensitivity.value,
+            "RELATIVE sensitivity ignores absolute paths so cache hits work across machines.",
         )
     }
 }


### PR DESCRIPTION
## Description

Closes the collector-side gap in the issue #79 roadmap (PR 4 of the cache-correctness rollout).

**`FakeCollectorTask` becomes `@CacheableTask`** and gains a `sourceFakeRoots` `@InputFiles` property aggregating `FaktGenerateTask.generatedKotlinDir` outputs from the source project. The provider chain carries Gradle's `builtBy` link automatically — no string-matched `dependsOn`, which is the regression class tracked as KSP #2442 / #2595 / #2623 (R4 in the roadmap).

**`destinationDir` is now the routing root.** Previously the registration set it to a `_placeholder` directory and the action wrote one level up, so Gradle's build cache restored only the (empty) placeholder, never the routed files. `outputs.cacheIf` gates caching on `sourceFakeRoots` being wired — the legacy in-process path keeps its current correctness (no spurious cache hits).

**Subplugin scope narrowed.** `useExperimentalGenerateTask` only takes the cache-correct path on pure JVM Gradle projects. KMP projects fall through to the legacy in-process plugin under the flag because the worker drives `K2JVMCompiler` reflectively — metadata / native / wasm producers need `K2MetadataCompiler` et al. with matching common-stdlib classpaths. **Deferred follow-up.**

## Related Issue
Closes the collector portion of #79. Producer-side cache correctness for KMP-metadata/native compilations remains a follow-up.

## Type of Change
- [x] New feature
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted (`spotlessApply`)
- [x] Static analysis (`detekt`) green
- [x] API check (`apiCheck`) — `gradle-plugin.api` regenerated for `sourceFakeRoots`
- [x] All tests pass (`./gradlew :gradle-plugin:test` — 99 tests)
- [x] Generated code compiles
- [x] No undocumented breaking changes

## Tests added

| Suite | Test | What it proves |
|---|---|---|
| `FakeCollectorTaskTest` | `sourceFakeRoots populated WHEN action runs THEN routes by platform` | cache-correct path routes JVM + common fakes correctly |
| `FakeCollectorTaskTest` | `empty sourceFakeRoots WHEN action runs THEN falls back to legacy polling` | legacy in-process path still works |
| `FakeCollectorTaskTest` | `sourceFakeRoots property WHEN inspected via reflection THEN carries @InputFiles + RELATIVE` | guards the annotation contract that makes the cache key relocatable |
| `FakeCollectorTaskCacheTest` (TestKit, new) | `populated cache WHEN running clean rebuild THEN collector reports FROM-CACHE` | the literal #79 regression at collector level |
| `FakeCollectorTaskCacheTest` (TestKit, new) | `collector wired via TaskProvider chain WHEN running collector alone THEN producer is triggered implicitly` | R4 builtBy-chain canary |

## Sample matrix verified

| Sample | Flag | Result |
|---|---|---|
| `jvm-single-module` | off | ✅ |
| `jvm-single-module` | on (cache-correct) | ✅ |
| `kmp-multi-module` | off | ✅ |
| `kmp-multi-module` | on (KMP falls through to legacy) | ✅ |

## Known limitation (call out at review)

KMP modules don't yet ride the cache-correct path under the flag — the worker's `K2JVMCompiler` reflection driver can't analyze `commonMain` / Native / Wasm. Two workarounds were considered and rejected for this PR:

1. **Disable the legacy plugin entirely under the flag** → fakes for `commonMain` `@Fake` interfaces never get generated.
2. **Run `FaktGenerateTask` on `jvmMain` only** → it analyzes `jvmMain + commonMain` (KGP source-set inheritance) and produces duplicate fakes alongside the legacy `compileKotlinMetadata` output, causing `Redeclaration:` errors at platform-test compile time.

The proper fix requires a `K2MetadataCompiler` (and probably `K2NativeCompiler`) driver in the worker + consumer-mode wiring of `commonFirMetadata` on platform tasks — substantial work, separate PR. Tracking as a follow-up.

## What's left in the roadmap

- ⏭️ **PR 4.x (deferred follow-up):** K2MetadataCompiler producer + KMP cache-correct path.
- ⏭️ **PR 5:** CI regression test (`#79` reproducer in `development.yml`) + flip the flag default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)