### PR TITLE
chore(gradle-plugin): remove process-narration comments

### DIFF
--- a/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/core/types/IrTypeSemantics.kt
+++ b/compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/core/types/IrTypeSemantics.kt
@@ -96,11 +96,7 @@ internal class IrTypeSemantics(private val typeRenderer: TypeRenderer) {
         return result
     }
 
-    /**
-     * Fills [into] with FQNs for [irType] and all nested type arguments.
-     *
-     * Split from [collectFqns] to honour detekt's [ReturnCount] threshold.
-     */
+    /** Fills [into] with FQNs for [irType] and all nested type arguments. */
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     private fun collectFqnsInto(
         irType: IrType,

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTask.kt
@@ -81,9 +81,8 @@ public abstract class FakeCollectorTask : DefaultTask() {
     /**
      * Aggregated `generatedKotlinDir` outputs of every [FaktGenerateTask] registered on the source
      * project. Wired through `ConfigurableFileCollection.from(Provider)` so Gradle carries the
-     * `builtBy` chain automatically — no `dependsOn(matching { name == "compile…" })` needed, which
-     * is the regression class tracked as KSP #2442 / #2595 / #2623 (R4 in the cache-correctness
-     * roadmap).
+     * `builtBy` chain automatically — no string-matched `dependsOn(matching { name == "compile…"
+     * })`, which silently breaks the dependency chain when task names change.
      *
      * Declared `@InputFiles` rather than `@Internal` so the collector's own cache key fingerprints
      * the source `.kt` payload — the cache-correct path is end-to-end, not just at the producer.
@@ -127,8 +126,8 @@ public abstract class FakeCollectorTask : DefaultTask() {
 
         // Caching is only correct when sources arrive through `sourceFakeRoots`. Under the legacy
         // in-process path the action polls `sourceGeneratedDir` at execution time — not declared as
-        // an input, so any "cache hit" would be a stale-output bug. Once PR 5 retires the legacy
-        // path this gate can disappear and the task becomes unconditionally cacheable.
+        // an input, so any "cache hit" would be a stale-output bug. This gate goes away together
+        // with the legacy path, making the task unconditionally cacheable.
         @Suppress("LeakingThis")
         outputs.cacheIf("sourceFakeRoots wired (cache-correct path)") { !sourceFakeRoots.isEmpty }
     }
@@ -142,8 +141,8 @@ public abstract class FakeCollectorTask : DefaultTask() {
         val sourceSetNames = availableSourceSets.getOrElse(mutableSetOf())
         // `destinationDir` is the routing root — platform subdirs (`jvmMain/kotlin/...`) are
         // written directly under it so Gradle's build cache fingerprints every routed file as part
-        // of this task's @OutputDirectory. Earlier code aliased it as a `_placeholder` dir and
-        // wrote one level up, which silently disabled cache restore for the collector (PR 4).
+        // of this task's @OutputDirectory. Writing outside this root silently disables cache
+        // restore for the collector.
         val destinationBaseDir = destinationDir.asFile.get()
         val platformStats = mutableMapOf<String, Int>()
         val totalCollected =
@@ -482,8 +481,8 @@ public abstract class FakeCollectorTask : DefaultTask() {
 
                     // Cache-correct path. `from(Provider)` carries `builtBy` automatically so the
                     // collector waits for every `FaktGenerateTask` on the source project — no
-                    // string-matched `dependsOn(matching { ... })`, which is the regression class
-                    // tracked as KSP #2442 / #2595 / #2623. Empty under the legacy in-process path.
+                    // string-matched `dependsOn(matching { ... })`. Empty under the legacy
+                    // in-process path.
                     it.sourceFakeRoots.from(
                         srcProject.tasks.withType(FaktGenerateTask::class.java).map { generateTask
                             ->
@@ -492,14 +491,14 @@ public abstract class FakeCollectorTask : DefaultTask() {
                     )
 
                     // Legacy fallback: source project still on the in-process compiler-plugin path.
-                    // Polled at execution time; not a declared input. PR 5 removes this path.
+                    // Polled at execution time; not a declared input.
                     it.sourceGeneratedDir.set(
                         srcProject.layout.buildDirectory.dir("generated/fakt")
                     )
 
                     // Routing root for platform-specific collection. The action creates
                     // subdirectories `commonMain/kotlin`, `jvmMain/kotlin`, … directly under this
-                    // dir, so the build cache fingerprints every routed file (PR 4).
+                    // dir, so the build cache fingerprints every routed file.
                     it.destinationDir.set(
                         project.layout.buildDirectory.dir("generated/collected-fakes")
                     )
@@ -603,7 +602,7 @@ public abstract class FakeCollectorTask : DefaultTask() {
                         }
                     )
 
-                    // Legacy fallback (in-process compiler plugin). Removed in PR 5.
+                    // Legacy fallback (in-process compiler plugin).
                     it.sourceGeneratedDir.set(
                         srcProject.layout.buildDirectory.dir("generated/fakt")
                     )

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
@@ -36,23 +36,19 @@ import org.gradle.workers.WorkerExecutor
  *
  * The task hosts `kotlin-compiler-embeddable` in an isolated [WorkerExecutor.classLoaderIsolation]
  * worker so the daemon doesn't carry the compiler classpath and so static state inside the FIR
- * pipeline can't leak across invocations. The reference architecture is KSP2's `KspAATask`
- * (research artifact 1, §"KSP2 / `KspAATask`").
+ * pipeline can't leak across invocations. The reference architecture is KSP2's `KspAATask`.
  *
  * Caching contract:
  * - Sources: [sources] is `@PathSensitive(RELATIVE)` — Kotlin file paths encode package, so
- *   relative is required for cross-machine cache hits (research artifact 2, §2).
+ *   relative is required for cross-machine cache hits.
  * - Classpaths use `@Classpath` / `@CompileClasspath` so ABI changes invalidate but trivial
  *   manifest edits don't.
  * - Outputs are split: [generatedKotlinDir] holds the `.kt` files (downstream `compileKotlin*`
- *   consumes via `kotlin.srcDir(taskProvider)` from PR 3 onward); [firMetadataFile] is the
- *   producer-mode KMP metadata cache, declared as a single `@OutputFile` rather than a directory so
- *   it can't overlap with platform-task outputs (research artifact 2, §6).
+ *   consumes via `kotlin.srcDir(taskProvider)`); [firMetadataFile] is the producer-mode KMP
+ *   metadata cache, declared as a single `@OutputFile` rather than a directory so it can't overlap
+ *   with platform-task outputs.
  * - [scratchDir] is `@LocalState` so a build-cache restore wipes it instead of replaying stale
- *   contents (KSP issue #2042 lesson).
- *
- * Wiring this task into `compileKotlin*` is deliberately deferred to PR 3; this PR just defines the
- * task and exercises it through Gradle TestKit.
+ *   contents.
  */
 @CacheableTask
 public abstract class FaktGenerateTask @Inject constructor(private val workers: WorkerExecutor) :
@@ -70,8 +66,7 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
 
     /**
      * Classpath for the Fakt worker — `kotlin-compiler-embeddable` (the `K2JVMCompiler` driver).
-     * Held isolated from the Gradle daemon to avoid clashes with KGP's bundled compiler (research
-     * artifact 1, R2).
+     * Held isolated from the Gradle daemon to avoid clashes with KGP's bundled compiler.
      */
     @get:Classpath public abstract val faktWorkerClasspath: ConfigurableFileCollection
 
@@ -105,7 +100,7 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
 
     /**
      * KMP consumer-mode input: serialized `FirMetadataCache` produced by an upstream `commonMain`
-     * task. Wired in PR 3 once per-target tasks are registered.
+     * task.
      *
      * `PathSensitivity.NONE` because only the file's contents matter — its absolute path on the
      * producer host is irrelevant for cache equality.
@@ -118,7 +113,7 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
     /**
      * Generated `Fake<X>Impl.kt` files. Convention is
      * `build/generated/fakt/<target>/<sourceSet>/kotlin` — disjoint from `compileKotlin*`'s outputs
-     * to avoid Gradle's overlapping-outputs rule (research artifact 2, §6).
+     * to avoid Gradle's overlapping-outputs rule.
      */
     @get:OutputDirectory public abstract val generatedKotlinDir: DirectoryProperty
 
@@ -129,7 +124,7 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
      */
     @get:OutputFile @get:Optional public abstract val firMetadataFile: RegularFileProperty
 
-    /** Internal scratch state — cleared on cache restore (KSP #2042 lesson). */
+    /** Internal scratch state — cleared on cache restore instead of being replayed. */
     @get:LocalState public abstract val scratchDir: DirectoryProperty
 
     @TaskAction

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
@@ -13,8 +13,7 @@ import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 
 /**
  * Registers a `FaktGenerateTask` for a single Kotlin compilation and wires its `@OutputDirectory`
- * into the matching test source set. Extracted from [FaktGradleSubplugin] so the entry-point class
- * stays under detekt's per-class function-count threshold.
+ * into the matching test source set.
  *
  * Cross-classloader contract: every method here is plain Gradle API + the Fakt
  * [com.rsicarelli.fakt.compiler.api.SourceSetContext] data class. Nothing in

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -135,9 +135,9 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                     ensureFaktConfigurations(target)
                 } else {
                     // Legacy in-process path. Also taken when the flag is on but the project is
-                    // KMP — the cache-correct worker only drives K2JVMCompiler today, so a
-                    // metadata/native producer is a deferred follow-up. Until then, KMP falls
-                    // through to the legacy wiring unchanged.
+                    // KMP — the cache-correct worker only drives K2JVMCompiler, which can't
+                    // compile metadata/native, so KMP falls through to the legacy wiring
+                    // unchanged.
                     val configurator = SourceSetConfigurator(target, useTestFixtures)
                     configurator.configureSourceSets()
                 }
@@ -356,8 +356,8 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
      * The cache-correct worker drives `K2JVMCompiler` reflectively, so it can only analyse JVM
      * bytecode-producing compilations. Two further constraints narrow the scope:
      * 1. **Platform.** KMP metadata, Native, JS and Wasm compilations need their own K2 drivers
-     *    (`K2MetadataCompiler` et al.) plus matching common/native stdlib classpaths — deferred
-     *    follow-up.
+     *    (`K2MetadataCompiler` et al.) plus matching common/native stdlib classpaths, which the
+     *    worker does not provide.
      * 2. **KMP source-set inheritance.** Even on a JVM target inside a KMP project, the `jvmMain`
      *    compilation's analysis source set is `jvmMain + commonMain` (KGP attaches parent source
      *    sets). The task would generate fakes for `commonMain` `@Fake` interfaces too, conflicting

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
@@ -214,9 +214,9 @@ constructor(objects: ObjectFactory, private val project: Project) {
      *
      * Setting the value in the extension wins over the property if both are present.
      *
-     * Marked experimental during the rollout (PRs #97 → #100). The default flips in PR 5; this
-     * property becomes the explicit opt-out for one minor before the legacy in-process path is
-     * removed.
+     * Experimental while the task-based path stabilizes. The cache-correct path is intended to
+     * become the default, with this property remaining as an explicit opt-out until the legacy
+     * in-process path is removed.
      */
     public val useExperimentalGenerateTask: Property<Boolean> =
         objects.property(Boolean::class.java).convention(false)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfigurator.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfigurator.kt
@@ -76,8 +76,7 @@ internal class SourceSetConfigurator(
     private fun configureKmpSourceSets(kotlin: KotlinMultiplatformExtension) {
         val buildDir = project.layout.buildDirectory.get().asFile
 
-        // PASS 1: Add source-set-specific generated directories
-        // Each test source set gets its own generated directory
+        // Add a per-source-set generated directory to every test source set.
         // Example: jvmTest → build/generated/fakt/jvmTest/kotlin
         kotlin.sourceSets.configureEach { sourceSet ->
             if (sourceSet.name.endsWith("Test")) {
@@ -87,39 +86,17 @@ internal class SourceSetConfigurator(
             }
         }
 
-        // PASS 2: Add commonTest directory to LEAF platform test source sets only
-        // This is CRITICAL for KMP projects where the compiler outputs fakes to commonTest
-        // when the interface is in commonMain (see SourceSetDiscovery.kt:176-184)
-        //
-        // Why: Compiler outputs to commonTest for common interfaces, but platform tests
-        // (iosX64Test, jvmTest, etc.) need to see those fakes too.
-        //
-        // IMPORTANT: We skip intermediate source sets (nativeTest, appleTest, etc.) because
-        // they already have a dependency relationship with commonTest through KMP's hierarchy.
-        // Adding the directory to them would cause "can be a part of only one module" errors.
-
-        // Only register if commonTest exists in the project
+        // Test source sets receive only their own generated directory. commonTest fakes reach
+        // platform tests (jvmTest, iosX64Test, …) through KMP's compilation model, which
+        // propagates compiled KLIBs through the source-set hierarchy. Adding commonTest's
+        // directory to platform test source sets directly would compile the same files into
+        // multiple modules and fail with "can be a part of only one module".
         val hasCommonTest = kotlin.sourceSets.findByName("commonTest") != null
 
         if (hasCommonTest) {
             project.logger.debug(
-                "Fakt: PASS 2 is disabled - KMP dependency propagation handles code visibility"
+                "Fakt: relying on KMP dependency propagation for commonTest fake visibility"
             )
-
-            // PASS 2 REMOVED: After extensive testing, we determined that explicitly adding
-            // commonTest source directories to platform test source sets causes
-            // "can be a part of only one module" compilation errors.
-            //
-            // The root cause is that KMP's compilation model propagates COMPILED code
-            // (KLIBs) from dependencies, not SOURCE directories. When we add the same
-            // source directory to multiple source sets, the Kotlin compiler sees the
-            // same files being compiled into multiple modules, which violates the
-            // "files can be a part of only one module" constraint.
-            //
-            // SOLUTION: The compiler plugin should output platform-specific fakes to
-            // platform-specific directories (e.g., iosX64Test instead of commonTest)
-            // when the interface is in a platform source set. This is tracked in
-            // compiler/src/main/kotlin/com/rsicarelli/fakt/compiler/ir/SourceSetDiscovery.kt
         }
     }
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
@@ -18,7 +18,7 @@ import org.gradle.workers.WorkParameters
 /**
  * Inputs to [FaktCodegenWorkAction]. All Gradle managed property types — raw `Project`,
  * `Configuration`, or `SourceDirectorySet` references would be forbidden under the configuration
- * cache (research artifact 1, R3).
+ * cache.
  */
 internal interface FaktCodegenWorkParameters : WorkParameters {
     val sources: ConfigurableFileCollection
@@ -182,7 +182,7 @@ internal abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParame
 
     private fun populateOutputArgs(bridge: K2CompilerBridge, args: Any, call: K2Invocation) {
         // K2 still needs a destination for `.class` output we never read. Route it to the task's
-        // `@LocalState scratchDir` so it never enters the build cache (audit MEDIUM #5).
+        // `@LocalState scratchDir` so it never enters the build cache.
         bridge.setOnArgs(
             args,
             "setDestination",
@@ -192,9 +192,7 @@ internal abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParame
         bridge.setOnArgs(args, "setNoStdlib", Boolean::class.javaPrimitiveType!!, true)
         bridge.setOnArgs(args, "setNoReflect", Boolean::class.javaPrimitiveType!!, true)
         // Leave the JDK on the compilation classpath — production sources reference
-        // `java.io.Serializable`, `java.util.*`, etc. K2 needs JDK rt to resolve them. The PR 2
-        // smoke tests got away with `noJdk=true` because kctfork supplied the JDK via
-        // `inheritClassPath = true`; the production worker doesn't.
+        // `java.io.Serializable`, `java.util.*`, etc. K2 needs JDK rt to resolve them.
     }
 
     private fun populatePluginArgs(bridge: K2CompilerBridge, args: Any, call: K2Invocation) {


### PR DESCRIPTION
## Description
Comment-only cleanup of the cache-correctness PR series (#97–#102). Rewrites or removes every development-process narration comment in production sources — PR-roadmap references ("PR 5 removes this", "deferred to PR 3"), research-artifact citations, audit-ticket references ("audit MEDIUM #5"), KSP issue numbers used as lessons-learned citations, and detekt-threshold justifications. These documented the *history of the change*, not the code (some were already false — "wiring is deferred to PR 3" while #101 did the wiring).

Genuine contracts/invariants are kept and rephrased as timeless functional statements:
- `FakeCollectorTask` `cacheIf` gate rationale (caching only correct when sources arrive through `sourceFakeRoots`)
- `FakeCollectorTask` collector-modules-expose-fakes-in-MAIN architecture block (kept verbatim)
- `@LocalState` / `@PathSensitive(RELATIVE)` / single-`@OutputFile` annotation rationale (reason kept, citations dropped)
- `FaktGradleSubplugin` live platform constraints (worker only drives `K2JVMCompiler`; no `K2MetadataCompiler` producer)
- `FirFakeMetadata.FirVisibility` KDoc judged compliant (genuine `explicitApi()` "why") — untouched

The abandoned two-pass "PASS 2 REMOVED" archaeology block in `SourceSetConfigurator` is replaced with a short positive rationale for the single-pass approach (commonTest fakes reach platform tests through KMP's KLIB propagation; adding the directory directly violates "can be a part of only one module").

**One non-comment line changed (deliberate):** the `logger.debug` string in `SourceSetConfigurator` referenced the removed "PASS 2" concept and was reworded to `"Fakt: relying on KMP dependency propagation for commonTest fake visibility"`. Zero behavior otherwise.

## Related Issue
Refs #79

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [ ] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test` (`:gradle-plugin:test :codegen-runtime:test :compiler:test`)
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context
Verification performed:
- Grep sweep returns 0 matches: `grep -rnE "PR [0-9] |PR #|PRs #|research artifact|audit (HIGH|MEDIUM|LOW)|detekt's|roadmap|kctfork" gradle-plugin/src/main codegen-runtime/src/main compiler/src/main`
- Straggler sweep (catches a line-break-split "research \n artifact" citation, `PASS N` labels, `§`-citations) also returns 0
- `./gradlew apiCheck` green — no `.api` changes, proving comment-only
- `./gradlew --configuration-cache :gradle-plugin:test` clean
- `git diff` reviewed: only comment lines plus the one debug-string reword above