### PR TITLE
docs(gradle-plugin): align KDoc with documentation standards

### DIFF
--- a/codegen-runtime/src/main/kotlin/com/rsicarelli/fakt/codegen/analysis/SpecToCodegenMapper.kt
+++ b/codegen-runtime/src/main/kotlin/com/rsicarelli/fakt/codegen/analysis/SpecToCodegenMapper.kt
@@ -68,7 +68,7 @@ internal fun DeclarationAnnotation.toAnnotationSpec(): AnnotationSpec =
         isOptInMarker = isOptInMarker,
     )
 
-/** @return Pair of (methods, properties) ready for `generateCompleteFake()`. */
+/** Maps interface members onto the renderer specs consumed by `generateCompleteFake()`. */
 internal fun FakeDeclaration.Interface.toCodegenSpecs():
     Pair<List<RenderableMethodSpec>, List<RenderablePropertySpec>> {
     val methodSpecs = functions.map { it.toRenderableMethodSpec() }

--- a/codegen-runtime/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/VisibilityExtensions.kt
+++ b/codegen-runtime/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/VisibilityExtensions.kt
@@ -8,7 +8,6 @@ import com.rsicarelli.fakt.codegen.builder.FunctionBuilder
 import com.rsicarelli.fakt.codegen.builder.PropertyBuilder
 import com.rsicarelli.fakt.compiler.fir.metadata.FirVisibility
 
-/** Applies visibility modifier to a [ClassBuilder]. */
 internal fun FirVisibility.applyVisibility(builder: ClassBuilder) {
     when (this) {
         FirVisibility.PUBLIC -> builder.public()
@@ -18,7 +17,6 @@ internal fun FirVisibility.applyVisibility(builder: ClassBuilder) {
     }
 }
 
-/** Applies visibility modifier to a [DataClassBuilder]. */
 internal fun FirVisibility.applyVisibility(builder: DataClassBuilder) {
     when (this) {
         FirVisibility.PUBLIC -> builder.public()
@@ -28,7 +26,6 @@ internal fun FirVisibility.applyVisibility(builder: DataClassBuilder) {
     }
 }
 
-/** Applies visibility modifier to a [FunctionBuilder]. */
 internal fun FirVisibility.applyVisibility(builder: FunctionBuilder) {
     when (this) {
         FirVisibility.PUBLIC -> builder.public()
@@ -38,7 +35,6 @@ internal fun FirVisibility.applyVisibility(builder: FunctionBuilder) {
     }
 }
 
-/** Applies visibility modifier to a [PropertyBuilder]. */
 internal fun FirVisibility.applyVisibility(builder: PropertyBuilder) {
     when (this) {
         FirVisibility.PUBLIC -> builder.public()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FakeCollectorTask.kt
@@ -40,6 +40,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
  * This solves the cross-platform compilation problem where JVM-only interfaces would fail to
  * compile in commonMain.
  *
+ * Operates in one of two modes: the cache-correct path, where [sourceFakeRoots] carries the source
+ * project's `FaktGenerateTask` outputs as declared inputs, and the legacy path, where
+ * [sourceGeneratedDir] is polled at execution time. Build caching is gated on the former via
+ * `outputs.cacheIf` — a legacy-path "cache hit" would replay stale outputs.
+ *
  * Example usage:
  * ```
  * foundation/              # Generates fakes for JVM + common interfaces
@@ -132,6 +137,11 @@ public abstract class FakeCollectorTask : DefaultTask() {
         outputs.cacheIf("sourceFakeRoots wired (cache-correct path)") { !sourceFakeRoots.isEmpty }
     }
 
+    /**
+     * Routes every collected fake into its platform source-set directory under [destinationDir].
+     * Reads from [sourceFakeRoots] when wired (cache-correct path) and falls back to polling
+     * [sourceGeneratedDir] otherwise (legacy path).
+     */
     @TaskAction
     public fun collectFakes() {
         val startTime = System.nanoTime()

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
@@ -38,30 +38,31 @@ import org.gradle.workers.WorkerExecutor
  * worker so the daemon doesn't carry the compiler classpath and so static state inside the FIR
  * pipeline can't leak across invocations. The reference architecture is KSP2's `KspAATask`.
  *
- * Caching contract:
- * - Sources: [sources] is `@PathSensitive(RELATIVE)` — Kotlin file paths encode package, so
- *   relative is required for cross-machine cache hits.
- * - Classpaths use `@Classpath` / `@CompileClasspath` so ABI changes invalidate but trivial
- *   manifest edits don't.
- * - Outputs are split: [generatedKotlinDir] holds the `.kt` files (downstream `compileKotlin*`
- *   consumes via `kotlin.srcDir(taskProvider)`); [firMetadataFile] is the producer-mode KMP
- *   metadata cache, declared as a single `@OutputFile` rather than a directory so it can't overlap
- *   with platform-task outputs.
- * - [scratchDir] is `@LocalState` so a build-cache restore wipes it instead of replaying stale
- *   contents.
+ * Caching semantics (path sensitivity, classpath normalization, output split, local state) are
+ * documented on each annotated property. For KMP, the task runs in producer mode (writes
+ * [firMetadataFile]) or consumer mode (reads [commonFirMetadata]) — see those properties.
  */
 @CacheableTask
 public abstract class FaktGenerateTask @Inject constructor(private val workers: WorkerExecutor) :
     DefaultTask() {
 
-    /** Kotlin source files (or directories) that may carry `@Fake`-annotated declarations. */
+    /**
+     * Kotlin source files (or directories) that may carry `@Fake`-annotated declarations.
+     *
+     * `@PathSensitive(RELATIVE)` because Kotlin file paths encode the package; relative sensitivity
+     * keeps cache keys stable across machines and checkout locations.
+     */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:SkipWhenEmpty
     @get:IgnoreEmptyDirectories
     public abstract val sources: ConfigurableFileCollection
 
-    /** Compile classpath the FIR + IR pipeline analyses against. */
+    /**
+     * Compile classpath the FIR + IR pipeline analyses against. `@CompileClasspath` normalization
+     * means ABI changes in dependencies invalidate cached fakes while implementation-only changes
+     * don't.
+     */
     @get:CompileClasspath public abstract val compileClasspath: ConfigurableFileCollection
 
     /**
@@ -92,15 +93,15 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
      */
     @get:Input public abstract val faktVersion: Property<String>
 
-    /** Worker log verbosity. */
     @get:Input public abstract val logLevel: Property<LogLevel>
 
     /** Imports forced into every generated file (e.g. user-extension imports). */
     @get:Input public abstract val imports: ListProperty<String>
 
     /**
-     * KMP consumer-mode input: serialized `FirMetadataCache` produced by an upstream `commonMain`
-     * task.
+     * KMP consumer-mode input: serialized `FirMetadataCache` produced by the metadata compilation's
+     * [firMetadataFile]. Its presence is what switches the worker to consumer mode — common `@Fake`
+     * declarations are read from the cache instead of being re-validated.
      *
      * `PathSensitivity.NONE` because only the file's contents matter — its absolute path on the
      * producer host is irrelevant for cache equality.
@@ -119,8 +120,9 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
 
     /**
      * KMP producer-mode output: serialized `FirMetadataCache` written when this task represents the
-     * metadata compilation. A single file (not a directory) so consumer tasks can read it via
-     * `@InputFile` without overlapping outputs.
+     * metadata (`commonMain`) compilation — [FaktGenerateTaskWiring] sets it for metadata-like
+     * compilations only. Platform tasks consume it through [commonFirMetadata]. A single file (not
+     * a directory) so consumers can declare it `@InputFile` without overlapping outputs.
      */
     @get:OutputFile @get:Optional public abstract val firMetadataFile: RegularFileProperty
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -100,6 +100,13 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         private const val OUTPUT_PLACEHOLDER: String = "fakt://generated"
     }
 
+    /**
+     * Creates the `fakt { }` extension and, after evaluation, routes the project: collector mode
+     * registers [FakeCollectorTask]s for [FaktPluginExtension.collectFrom]; generator mode either
+     * wires legacy source sets ([SourceSetConfigurator]) or, with the experimental flag on,
+     * prepares the worker configurations — per-compilation [FaktGenerateTask] registration happens
+     * later in [applyToCompilation].
+     */
     @OptIn(ExperimentalFaktMultiModule::class)
     override fun apply(target: Project) {
         // Create the fakt extension for configuration

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
@@ -195,6 +195,10 @@ constructor(objects: ObjectFactory, private val project: Project) {
      * `compileKotlin*`, the generated `.kt` files come back too because they're declared task
      * outputs rather than side-effect writes.
      *
+     * When enabled, the in-process compiler-plugin registration is disabled and a
+     * `FaktGenerateTask` is registered per compilation, with its output wired into the matching
+     * test source set. KMP projects currently stay on the in-process path regardless of the flag.
+     *
      * **Default:** `false` (the existing in-process compiler-plugin path runs unchanged).
      *
      * **Usage (build script):**

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfigurator.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfigurator.kt
@@ -155,21 +155,7 @@ internal class SourceSetConfigurator(
         )
     }
 
-    /**
-     * Determines if a Kotlin compilation task is for tests (unit or instrumented).
-     *
-     * Includes:
-     * - JVM test tasks: compileTestKotlin, compileTestKotlinJvm
-     * - Android unit test tasks: compileDebugUnitTestKotlin, compileReleaseUnitTestKotlin
-     * - Android instrumented tests: compileDebugAndroidTestKotlin, compileReleaseAndroidTestKotlin
-     * - KMP instrumented tests: compileDebugInstrumentedTestKotlin
-     *
-     * Excludes:
-     * - Main/production tasks: compileKotlin, compileDebugKotlin, compileReleaseKotlin
-     *
-     * @param taskName The name of the compilation task
-     * @return true if this is a test compilation task (unit or instrumented), false otherwise
-     */
+    /** Matches unit and instrumented test compilations across JVM, Android, and KMP task names. */
     private fun isTestTask(taskName: String): Boolean {
         val normalized = taskName.lowercase()
         return normalized.contains("test")


### PR DESCRIPTION
## Description
KDoc audit of `:gradle-plugin` and `:codegen-runtime` against the project documentation standard, completing the doc pass for the #79 PR series (#97–#102, narration cleanup in #104).

**Added contract docs** (code can't say these):
- `FaktGenerateTask`: per-property caching semantics — why `@PathSensitive(RELATIVE)` on `sources` (paths encode package → cross-machine cache hits), `@CompileClasspath` ABI-only invalidation, `@LocalState` scratch dir; class KDoc now points to per-property docs and names the producer/consumer mode pair.
- `FaktGenerateTask` producer vs consumer mode: `firMetadataFile` is set by `FaktGenerateTaskWiring` for metadata-like compilations only; `commonFirMetadata.isPresent` is what switches the worker to consumer mode.
- `FakeCollectorTask`: class-level dual-mode contract (cache-correct `sourceFakeRoots` vs legacy `sourceGeneratedDir` polling, `outputs.cacheIf` gate) and a `collectFakes()` summary.
- `FaktPluginExtension.useExperimentalGenerateTask`: what changes when enabled (in-process registrar disabled, per-compilation task registered, test source-set wiring) and the KMP fallback.
- `FaktGradleSubplugin.apply()`: entry-point routing (collector vs generator mode, where task registration happens).

**Deleted** signature-restating KDoc: `FaktGenerateTask.logLevel` ("Worker log verbosity."), four `applyVisibility` one-liners in `VisibilityExtensions.kt`; trimmed the 15-line KDoc on the trivial `isTestTask` private helper to one line.

**Style fix**: bare `@return Pair of (methods, properties)` in `SpecToCodegenMapper.kt` → proper summary sentence.

## Related Issue
Refs #79

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [ ] Linter passing: `./gradlew lintKotlin` (task does not exist in this build; Spotless covers formatting)
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew :gradle-plugin:test :codegen-runtime:test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context
Documentation-standard checklist applied in full (self-documenting-first, contract-only KDoc, semantic `@param`/`@property`, `[Ref]`/backticks, no implementation details in public KDoc). Verified zero `{@link}`/`{@code}` Javadoc syntax in both modules.

Deliberate exceptions:
- `imports` keeps its one-liner — "forced into every generated file" is semantics the name alone doesn't carry.
- Public KDoc on `firMetadataFile` references the internal `FaktGenerateTaskWiring` — naming who wires the producer mode was judged worth the internal reference for contributors.

Rename/extract follow-up candidates (rename-beats-doc rule): none found — both module audits judged existing naming clear.

Doc-only proof: `apiCheck` green with no `.api` changes; `--configuration-cache :gradle-plugin:test` clean; diff contains only KDoc/comment lines.