### PR TITLE
test(gradle-plugin): close coverage gaps from cache-correctness series

### DIFF
--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiringTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiringTest.kt
@@ -1,0 +1,228 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import com.rsicarelli.fakt.gradle.helpers.createJvmProject
+import com.rsicarelli.fakt.gradle.helpers.createKmpProject
+import com.rsicarelli.fakt.gradle.helpers.evaluate
+import com.rsicarelli.fakt.gradle.helpers.getKotlinExtension
+import com.rsicarelli.fakt.gradle.helpers.jvmCompilation
+import com.rsicarelli.fakt.gradle.helpers.kmpCompilation
+import java.io.File
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Pins the per-compilation contract of [FaktGenerateTaskWiring.register]: task naming, idempotent
+ * registration, configuration bootstrap, test-source-set wiring (JVM and KMP variants), and the KMP
+ * cross-target `dependsOn` chain.
+ *
+ * Each test drives `register` directly with a **real** [KotlinCompilation] obtained from
+ * `ProjectBuilder` + the Kotlin Gradle Plugin — the minimal fakes in `fakes/` throw on members
+ * `register` dereferences (`allKotlinSourceSets`, `compileDependencyFiles`). KGP does not invoke
+ * `applyToCompilation` under `ProjectBuilder`, so calling `register` directly is the unit seam; the
+ * flag-driven end-to-end path is covered by [FaktGradleSubpluginFlagResolutionTest] and the CI
+ * sample matrix.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktGenerateTaskWiringTest {
+
+    private fun evaluatedJvmProject(projectDir: File): Project =
+        createJvmProject(projectDir).also { it.evaluate() }
+
+    /** KMP project with jvm + linuxX64 targets so the metadata `commonMain` compilation exists. */
+    private fun evaluatedKmpProject(): Project =
+        createKmpProject().also { project ->
+            project.getKotlinExtension().jvm()
+            project.getKotlinExtension().linuxX64()
+            project.evaluate()
+        }
+
+    private fun Project.faktExtension(): FaktPluginExtension =
+        extensions.getByType(FaktPluginExtension::class.java)
+
+    private fun Project.registerWiring(targetName: String, compilationName: String) {
+        FaktGenerateTaskWiring.register(
+            this,
+            kmpCompilation(targetName, compilationName),
+            faktExtension(),
+        )
+    }
+
+    @Test
+    fun `GIVEN JVM main compilation WHEN register THEN registers task named faktGenerateJvmMain`(
+        @TempDir tempDir: File
+    ) {
+        val project = evaluatedJvmProject(tempDir)
+
+        FaktGenerateTaskWiring.register(
+            project,
+            project.jvmCompilation("main"),
+            project.faktExtension(),
+        )
+
+        assertNotNull(
+            project.tasks.findByName("faktGenerateJvmMain"),
+            "Single-platform JVM has a blank targetName — the platform-type fallback must " +
+                "produce faktGenerateJvmMain; tasks: ${project.tasks.names.filter { it.startsWith("fakt") }}",
+        )
+    }
+
+    @Test
+    fun `GIVEN KMP metadata commonMain compilation WHEN register THEN registers task named faktGenerateMetadataCommonMain`() {
+        val project = evaluatedKmpProject()
+
+        project.registerWiring("metadata", "commonMain")
+
+        assertNotNull(
+            project.tasks.findByName("faktGenerateMetadataCommonMain"),
+            "Metadata commonMain compilation must map to faktGenerateMetadataCommonMain; " +
+                "tasks: ${project.tasks.names.filter { it.startsWith("fakt") }}",
+        )
+    }
+
+    @Test
+    fun `GIVEN register called twice for same compilation WHEN second call THEN no duplicate task and no error`(
+        @TempDir tempDir: File
+    ) {
+        val project = evaluatedJvmProject(tempDir)
+        val compilation = project.jvmCompilation("main")
+        val extension = project.faktExtension()
+        FaktGenerateTaskWiring.register(project, compilation, extension)
+
+        // Must be a silent no-op: without the existence guard Gradle throws on duplicate names.
+        FaktGenerateTaskWiring.register(project, compilation, extension)
+
+        assertNotNull(project.tasks.findByName("faktGenerateJvmMain"))
+    }
+
+    @Test
+    fun `GIVEN JVM project WHEN register THEN faktWorker and faktCompiler configurations created`(
+        @TempDir tempDir: File
+    ) {
+        val project = evaluatedJvmProject(tempDir)
+
+        FaktGenerateTaskWiring.register(
+            project,
+            project.jvmCompilation("main"),
+            project.faktExtension(),
+        )
+
+        assertNotNull(
+            project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION),
+            "register fires before afterEvaluate in the real flow — it must bootstrap faktWorker.",
+        )
+        assertNotNull(
+            project.configurations.findByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION),
+            "register must bootstrap faktCompiler alongside faktWorker.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag created configurations on evaluate WHEN register runs afterwards THEN configuration creation is idempotent`(
+        @TempDir tempDir: File
+    ) {
+        val project = createJvmProject(tempDir)
+        project.faktExtension().useExperimentalGenerateTask.set(true)
+        project.evaluate()
+        assertNotNull(
+            project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION),
+            "Precondition: afterEvaluate with flag=true must have created faktWorker.",
+        )
+
+        // Second creation site (registration-time) must be safe after the afterEvaluate one.
+        FaktGenerateTaskWiring.register(
+            project,
+            project.jvmCompilation("main"),
+            project.faktExtension(),
+        )
+
+        assertNotNull(project.tasks.findByName("faktGenerateJvmMain"))
+        assertNotNull(project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION))
+        assertNotNull(
+            project.configurations.findByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION)
+        )
+    }
+
+    @Test
+    fun `GIVEN JVM main compilation WHEN register THEN generated dir wired into compileTestKotlin sources`(
+        @TempDir tempDir: File
+    ) {
+        val project = evaluatedJvmProject(tempDir)
+        // The compile task's `sources` resolves as a live file tree — plant a marker so the
+        // wired directory is observable without executing the generate task.
+        val generatedDir =
+            File(project.layout.buildDirectory.get().asFile, "generated/fakt/jvm/main/kotlin")
+        generatedDir.mkdirs()
+        val marker = File(generatedDir, "Marker.kt").apply { writeText("// marker\n") }
+
+        FaktGenerateTaskWiring.register(
+            project,
+            project.jvmCompilation("main"),
+            project.faktExtension(),
+        )
+
+        val testTask = project.tasks.getByName("compileTestKotlin") as AbstractKotlinCompile<*>
+        assertTrue(
+            testTask.sources.files.contains(marker),
+            "JVM-only projects wire the generated dir into *Test compile tasks via source(); " +
+                "sources: ${testTask.sources.files}",
+        )
+    }
+
+    @Test
+    fun `GIVEN KMP jvm main compilation WHEN register THEN generated dir added to jvmTest kotlin srcDir`() {
+        val project = evaluatedKmpProject()
+
+        project.registerWiring("jvm", "main")
+
+        val jvmTestSrcDirs =
+            project.getKotlinExtension().sourceSets.getByName("jvmTest").kotlin.srcDirs
+        assertTrue(
+            jvmTestSrcDirs.any { it.path.endsWith("generated/fakt/jvm/main/kotlin") },
+            "KMP projects wire the generated dir as a jvmTest srcDir via the task provider; " +
+                "srcDirs: $jvmTestSrcDirs",
+        )
+    }
+
+    @Test
+    fun `GIVEN KMP jvm main compilation WHEN register after commonMain THEN platform task dependsOn metadata counterpart`() {
+        val project = evaluatedKmpProject()
+        project.registerWiring("metadata", "commonMain")
+        val commonTask = project.tasks.getByName("faktGenerateMetadataCommonMain")
+
+        project.registerWiring("jvm", "main")
+
+        // taskProvider.configure {} is lazy — realizing the task applies the dependsOn wiring.
+        val platformTask = project.tasks.getByName("faktGenerateJvmMain")
+        assertTrue(
+            platformTask.dependsOn.contains(commonTask),
+            "Platform faktGenerate tasks must depend on the commonMain counterpart so common " +
+                "@Fake declarations are validated once; dependsOn: ${platformTask.dependsOn}",
+        )
+    }
+
+    @Test
+    fun `GIVEN KMP metadata commonMain compilation WHEN register THEN no dependsOn wiring added`() {
+        val project = evaluatedKmpProject()
+
+        project.registerWiring("metadata", "commonMain")
+
+        val commonTask = project.tasks.getByName("faktGenerateMetadataCommonMain")
+        val faktTaskDependencies =
+            commonTask.dependsOn.filterIsInstance<Task>().filter {
+                it.name.startsWith("faktGenerate")
+            }
+        assertTrue(
+            faktTaskDependencies.isEmpty(),
+            "commonMain is the root of the chain — it must not depend on any faktGenerate task; " +
+                "found: $faktTaskDependencies",
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
@@ -1,0 +1,236 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import com.rsicarelli.fakt.gradle.helpers.createJvmProject
+import com.rsicarelli.fakt.gradle.helpers.createKmpProject
+import com.rsicarelli.fakt.gradle.helpers.evaluate
+import com.rsicarelli.fakt.gradle.helpers.getKotlinExtension
+import com.rsicarelli.fakt.gradle.helpers.jvmCompilation
+import com.rsicarelli.fakt.gradle.helpers.kmpCompilation
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Pins how `fakt.useExperimentalGenerateTask` is resolved and what [FaktGradleSubplugin] hands the
+ * compiler for each outcome.
+ *
+ * Two harnesses:
+ * - `ProjectBuilder` drives the public [FaktGradleSubplugin.applyToCompilation] /
+ *   [FaktGradleSubplugin.isApplicable] seams directly with real compilations — covers the
+ *   extension-set branch, the both-unset default, the KMP veto, and test-compilation skipping.
+ * - Gradle TestKit covers the `gradleProperty` branches: `ProjectBuilder` cannot inject Gradle
+ *   properties (they come from start parameters), so a synthetic build passing `-P` flags is the
+ *   only faithful seam. The TestKit builds only run `tasks --all` — configuration-time probing,
+ *   never task execution.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktGradleSubpluginFlagResolutionTest {
+
+    private fun Project.faktSubplugin(): FaktGradleSubplugin =
+        plugins.getPlugin(FaktGradleSubplugin::class.java)
+
+    private fun Project.faktExtension(): FaktPluginExtension =
+        extensions.getByType(FaktPluginExtension::class.java)
+
+    @Test
+    fun `GIVEN flag true via extension AND JVM project WHEN applyToCompilation THEN returns single enabled false option`(
+        @TempDir tempDir: File
+    ) {
+        val project = createJvmProject(tempDir)
+        project.faktExtension().useExperimentalGenerateTask.set(true)
+        project.evaluate()
+
+        val options =
+            project.faktSubplugin().applyToCompilation(project.jvmCompilation("main")).get()
+
+        assertEquals(
+            1,
+            options.size,
+            "Cache-correct path must hand the in-process plugin exactly one option.",
+        )
+        assertEquals("enabled", options.single().key)
+        assertEquals(
+            "false",
+            options.single().value,
+            "enabled=false tells the in-process registrar to exit early — generation moves to FaktGenerateTask.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag unset WHEN applyToCompilation on JVM THEN returns legacy options`(
+        @TempDir tempDir: File
+    ) {
+        val project = createJvmProject(tempDir)
+        project.evaluate()
+
+        val options =
+            project.faktSubplugin().applyToCompilation(project.jvmCompilation("main")).get()
+
+        val keys = options.map { it.key }
+        assertEquals(
+            listOf(
+                "enabled",
+                "logLevel",
+                "enableCallHistory",
+                "enableMutableFakes",
+                "sourceSetContext",
+                "outputDir",
+            ),
+            keys,
+            "Extension unset + property unset must resolve to false and keep the legacy payload.",
+        )
+        assertEquals("true", options.first { it.key == "enabled" }.value)
+    }
+
+    @Test
+    fun `GIVEN flag true via extension AND KMP project WHEN applyToCompilation THEN returns legacy options`() {
+        val project = createKmpProject()
+        project.getKotlinExtension().jvm()
+        project.faktExtension().useExperimentalGenerateTask.set(true)
+        project.evaluate()
+
+        val options =
+            project.faktSubplugin().applyToCompilation(project.kmpCompilation("jvm", "main")).get()
+
+        assertTrue(
+            options.any { it.key == "sourceSetContext" },
+            "KMP must veto the cache-correct path — the worker only drives K2JVMCompiler; " +
+                "keys: ${options.map { it.key }}",
+        )
+        assertTrue(project.tasks.names.none { it.startsWith("faktGenerate") })
+    }
+
+    @Test
+    fun `GIVEN JVM test compilation WHEN isApplicable THEN returns false`(@TempDir tempDir: File) {
+        val project = createJvmProject(tempDir)
+        project.evaluate()
+        val subplugin = project.faktSubplugin()
+
+        assertFalse(
+            subplugin.isApplicable(project.jvmCompilation("test")),
+            "Test compilations only consume generated fakes — no FaktGenerateTask for them.",
+        )
+        assertTrue(
+            subplugin.isApplicable(project.jvmCompilation("main")),
+            "Main compilations carry the @Fake declarations and must stay applicable.",
+        )
+    }
+
+    // -- TestKit: gradleProperty branches ---------------------------------------------------------
+
+    @Test
+    fun `GIVEN gradle property true and extension unset WHEN building THEN faktGenerateJvmMain registered`(
+        @TempDir projectDir: File
+    ) {
+        setupKotlinJvmFaktProject(projectDir)
+
+        val result = listTasks(projectDir, "-Pfakt.useExperimentalGenerateTask=true")
+
+        assertTrue(
+            result.output.contains("faktGenerateJvmMain"),
+            "Property true with extension unset must win and register the generate task.",
+        )
+    }
+
+    @Test
+    fun `GIVEN gradle property yes WHEN building THEN treated as false and no faktGenerate task`(
+        @TempDir projectDir: File
+    ) {
+        setupKotlinJvmFaktProject(projectDir)
+
+        val result = listTasks(projectDir, "-Pfakt.useExperimentalGenerateTask=yes")
+
+        assertFalse(
+            result.output.contains("faktGenerate"),
+            "Only strict 'true'/'false' parse — 'yes' must fall back to false.",
+        )
+    }
+
+    @Test
+    fun `GIVEN gradle property empty string WHEN building THEN treated as false and no faktGenerate task`(
+        @TempDir projectDir: File
+    ) {
+        setupKotlinJvmFaktProject(projectDir)
+
+        val result = listTasks(projectDir, "-Pfakt.useExperimentalGenerateTask=")
+
+        assertFalse(
+            result.output.contains("faktGenerate"),
+            "Empty property value must fall back to false, not crash or enable the path.",
+        )
+    }
+
+    @Test
+    fun `GIVEN extension false and gradle property true WHEN building THEN property wins and task registered`(
+        @TempDir projectDir: File
+    ) {
+        setupKotlinJvmFaktProject(
+            projectDir,
+            extensionBlock =
+                "extensions.getByType(com.rsicarelli.fakt.gradle.FaktPluginExtension::class.java)" +
+                    ".useExperimentalGenerateTask.set(false)",
+        )
+
+        val result = listTasks(projectDir, "-Pfakt.useExperimentalGenerateTask=true")
+
+        assertTrue(
+            result.output.contains("faktGenerateJvmMain"),
+            "Extension false does not veto the property — only extension TRUE short-circuits.",
+        )
+    }
+
+    /**
+     * Writes a synthetic Kotlin JVM project applying the real KGP + Fakt plugins from this test
+     * JVM's classpath. Unlike [FaktGenerateTaskTest]'s worker classpath, the buildscript classpath
+     * keeps `kotlin-gradle-plugin` — it is exactly what the synthetic build applies.
+     */
+    private fun setupKotlinJvmFaktProject(projectDir: File, extensionBlock: String = "") {
+        val classpathLiteral =
+            System.getProperty("java.class.path")
+                .split(File.pathSeparator)
+                .map(::File)
+                .filter { it.exists() && "kctfork" !in it.absolutePath }
+                .joinToString(",\n        ") { entry ->
+                    """file("${entry.absolutePath.replace('\\', '/')}")"""
+                }
+        projectDir
+            .resolve("settings.gradle.kts")
+            .writeText("""rootProject.name = "fakt-flag-test"""")
+        projectDir
+            .resolve("gradle.properties")
+            .writeText("org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1024m\n")
+        projectDir
+            .resolve("build.gradle.kts")
+            .writeText(
+                """
+                buildscript {
+                    dependencies {
+                        classpath(files($classpathLiteral))
+                    }
+                }
+
+                apply(plugin = "org.jetbrains.kotlin.jvm")
+                apply(plugin = "com.rsicarelli.fakt")
+
+                $extensionBlock
+                """
+                    .trimIndent()
+            )
+    }
+
+    private fun listTasks(projectDir: File, vararg arguments: String): BuildResult =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .forwardOutput()
+            .withArguments("tasks", "--all", *arguments, "--stacktrace")
+            .build()
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtensionDefaultsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtensionDefaultsTest.kt
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import com.rsicarelli.fakt.compiler.api.LogLevel
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Pins the [FaktPluginExtension] property defaults that no other suite covers.
+ *
+ * `enabled` and `enableCallHistory` defaults live in [FaktGradleSubpluginTest];
+ * `useExperimentalGenerateTask` default lives in [FaktExperimentalGenerateTaskWiringTest]. This
+ * suite covers the remaining conventions so a default flip can never land silently.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktPluginExtensionDefaultsTest {
+
+    private fun faktExtension(): FaktPluginExtension {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
+        return project.extensions.getByType(FaktPluginExtension::class.java)
+    }
+
+    @Test
+    fun `GIVEN plugin applied WHEN reading logLevel THEN defaults to INFO`() {
+        val extension = faktExtension()
+
+        assertEquals(
+            LogLevel.INFO,
+            extension.logLevel.get(),
+            "logLevel must default to INFO — concise summary without opting into DEBUG noise.",
+        )
+    }
+
+    @Test
+    fun `GIVEN plugin applied WHEN reading enableMutableFakes THEN defaults to false`() {
+        val extension = faktExtension()
+
+        assertFalse(
+            extension.enableMutableFakes.get(),
+            "enableMutableFakes must default to false — fakes are immutable unless opted in.",
+        )
+    }
+
+    @Test
+    fun `GIVEN plugin applied WHEN reading useGradleTestFixtures THEN defaults to false`() {
+        val extension = faktExtension()
+
+        assertFalse(
+            extension.useGradleTestFixtures.get(),
+            "useGradleTestFixtures must default to false — test source set is the default output.",
+        )
+    }
+
+    @OptIn(ExperimentalFaktMultiModule::class)
+    @Test
+    fun `GIVEN plugin applied WHEN reading collectFrom THEN is not present`() {
+        val extension = faktExtension()
+
+        assertFalse(
+            extension.collectFrom.isPresent,
+            "collectFrom must be unset by default — generator mode is the default mode.",
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfiguratorJvmTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfiguratorJvmTest.kt
@@ -1,0 +1,138 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Pins the JVM-only and testFixtures branches of [SourceSetConfigurator].
+ *
+ * The KMP branch (`configureKmpSourceSets`) is covered by [SimplifiedSourceSetConfigurationTest];
+ * this suite covers the `configureJvmSourceSets` task wiring, the `isTestTask` classification, and
+ * the `configureTestFixturesSourceSet` path with and without the `java-test-fixtures` plugin.
+ *
+ * The compile task's `sources` property resolves as a live file tree, so each test plants a marker
+ * `.kt` file inside the expected generated directory and asserts on its presence (or absence) in
+ * the realized compile task's sources — no task execution needed.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SourceSetConfiguratorJvmTest {
+
+    private fun createKotlinJvmProject(projectDir: File): Project {
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        project.group = "com.example"
+        project.version = "1.0.0"
+        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+        return project
+    }
+
+    /** Plants a marker file so the file tree behind the task's `sources` can see the dir. */
+    private fun plantMarker(project: Project, relativeDir: String): File {
+        val dir = File(project.layout.buildDirectory.get().asFile, relativeDir)
+        dir.mkdirs()
+        return File(dir, "Marker.kt").apply { writeText("// marker\n") }
+    }
+
+    private fun kotlinCompileTask(project: Project, name: String): AbstractKotlinCompile<*> =
+        project.tasks.getByName(name) as AbstractKotlinCompile<*>
+
+    @Test
+    fun `GIVEN JVM project without test fixtures WHEN configureSourceSets THEN compileTestKotlin includes generated test dir`(
+        @TempDir tempDir: File
+    ) {
+        val project = createKotlinJvmProject(tempDir)
+        val marker = plantMarker(project, "generated/fakt/test/kotlin")
+
+        SourceSetConfigurator(project, useTestFixtures = false).configureSourceSets()
+
+        val testTask = kotlinCompileTask(project, "compileTestKotlin")
+        assertTrue(
+            testTask.sources.files.contains(marker),
+            "compileTestKotlin must compile build/generated/fakt/test/kotlin; " +
+                "sources: ${testTask.sources.files}",
+        )
+    }
+
+    @Test
+    fun `GIVEN JVM project WHEN configureSourceSets THEN compileKotlin main does NOT include generated dir`(
+        @TempDir tempDir: File
+    ) {
+        val project = createKotlinJvmProject(tempDir)
+        val marker = plantMarker(project, "generated/fakt/test/kotlin")
+
+        SourceSetConfigurator(project, useTestFixtures = false).configureSourceSets()
+
+        val mainTask = kotlinCompileTask(project, "compileKotlin")
+        assertFalse(
+            mainTask.sources.files.contains(marker),
+            "Generated fakes must never leak into the main compilation.",
+        )
+    }
+
+    @Test
+    fun `GIVEN useTestFixtures true AND java-test-fixtures applied WHEN configureSourceSets THEN testFixtures java srcDir includes generated dir`(
+        @TempDir tempDir: File
+    ) {
+        val project = createKotlinJvmProject(tempDir)
+        project.pluginManager.apply("java-test-fixtures")
+        val generatedDir =
+            File(project.layout.buildDirectory.get().asFile, "generated/fakt/testFixtures/kotlin")
+
+        SourceSetConfigurator(project, useTestFixtures = true).configureSourceSets()
+
+        val testFixturesSourceSet =
+            project.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets
+                .getByName("testFixtures")
+        assertTrue(
+            testFixturesSourceSet.java.srcDirs.contains(generatedDir),
+            "testFixtures java source set must include the generated dir; " +
+                "srcDirs: ${testFixturesSourceSet.java.srcDirs}",
+        )
+    }
+
+    @Test
+    fun `GIVEN useTestFixtures true AND java-test-fixtures NOT applied WHEN configureSourceSets THEN completes without error`(
+        @TempDir tempDir: File
+    ) {
+        val project = createKotlinJvmProject(tempDir)
+
+        SourceSetConfigurator(project, useTestFixtures = true).configureSourceSets()
+
+        assertNull(
+            project.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets
+                .findByName("testFixtures"),
+            "Without java-test-fixtures the source set must not exist — wiring is a no-op.",
+        )
+    }
+
+    @Test
+    fun `GIVEN useTestFixtures true WHEN configureSourceSets THEN JVM test task wiring is skipped`(
+        @TempDir tempDir: File
+    ) {
+        val project = createKotlinJvmProject(tempDir)
+        project.pluginManager.apply("java-test-fixtures")
+        val marker = plantMarker(project, "generated/fakt/test/kotlin")
+
+        SourceSetConfigurator(project, useTestFixtures = true).configureSourceSets()
+
+        val testTask = kotlinCompileTask(project, "compileTestKotlin")
+        assertFalse(
+            testTask.sources.files.contains(marker),
+            "testFixtures mode must short-circuit the default test source-set wiring.",
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/helpers/TestHelpers.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/helpers/TestHelpers.kt
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.rsicarelli.fakt.gradle.helpers
 
+import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 
 /**
  * Creates a test project with Kotlin Multiplatform and Fakt plugins applied.
@@ -21,6 +24,46 @@ internal fun createKmpProject(): Project {
     project.pluginManager.apply("com.rsicarelli.fakt")
     return project
 }
+
+/**
+ * Creates a test project with Kotlin JVM and Fakt plugins applied.
+ *
+ * @param projectDir Project directory, typically a JUnit `@TempDir`
+ * @return Configured test project
+ */
+internal fun createJvmProject(projectDir: File): Project {
+    val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+    project.group = "com.example"
+    project.version = "1.0.0"
+    project.pluginManager.apply("org.jetbrains.kotlin.jvm")
+    project.pluginManager.apply("com.rsicarelli.fakt")
+    return project
+}
+
+/**
+ * Returns a real [KotlinCompilation] from the single-platform JVM target.
+ *
+ * Call after [evaluate] so the Kotlin Gradle Plugin has populated the compilation container.
+ *
+ * @param name Compilation name, e.g. `main` or `test`
+ */
+internal fun Project.jvmCompilation(name: String): KotlinCompilation<*> =
+    extensions.getByType(KotlinJvmProjectExtension::class.java).target.compilations.getByName(name)
+
+/**
+ * Returns a real [KotlinCompilation] from a KMP target.
+ *
+ * Call after [evaluate] so the Kotlin Gradle Plugin has populated the compilation containers. The
+ * metadata target owns the `commonMain` compilation when the project has multiple targets.
+ *
+ * @param targetName Target name, e.g. `jvm`, `linuxX64`, or `metadata`
+ * @param compilationName Compilation name, e.g. `main` or `commonMain`
+ */
+internal fun Project.kmpCompilation(
+    targetName: String,
+    compilationName: String,
+): KotlinCompilation<*> =
+    getKotlinExtension().targets.getByName(targetName).compilations.getByName(compilationName)
 
 /**
  * Gets the Kotlin Multiplatform extension from the project.


### PR DESCRIPTION
## Description

Test-only PR closing the coverage gaps left by the #79 cache-correctness series (#98–#102). `FaktExperimentalGenerateTaskWiringTest` only checked extension defaults and configuration existence — the actual per-compilation task registration, source-set wiring, `dependsOn` chain, and flag-resolution precedence were unpinned. This PR adds 26 tests across 4 new suites plus shared helpers.

Every test was red-green verified: the pinned production line was temporarily mutated, the test observed failing, and the mutation reverted. No production code changes were needed — all seams were reachable through `internal` visibility and the public `KotlinCompilerPluginSupportPlugin` API.

### New tests and the behavior each pins

#### `FaktGenerateTaskWiringTest` (driving `FaktGenerateTaskWiring.register` with real compilations)

| Test | Production behavior pinned |
|---|---|
| GIVEN JVM main compilation WHEN register THEN registers task named faktGenerateJvmMain | Blank `targetName` falls back to platform type → `faktGenerateJvmMain` |
| GIVEN KMP metadata commonMain compilation WHEN register THEN registers task named faktGenerateMetadataCommonMain | `taskNameFor` target+compilation naming contract |
| GIVEN register called twice for same compilation WHEN second call THEN no duplicate task and no error | `findByName` early-return guard |
| GIVEN JVM project WHEN register THEN faktWorker and faktCompiler configurations created | `ensureFaktConfigurations` bootstrap before `afterEvaluate` |
| GIVEN flag created configurations on evaluate WHEN register runs afterwards THEN configuration creation is idempotent | `maybeCreate` semantics — registration-time + afterEvaluate both safe |
| GIVEN JVM main compilation WHEN register THEN generated dir wired into compileTestKotlin sources | JVM-only branch: `AbstractKotlinCompile.source(provider)` on `*Test` tasks |
| GIVEN KMP jvm main compilation WHEN register THEN generated dir added to jvmTest kotlin srcDir | KMP branch: `kotlin.srcDir(taskProvider.flatMap { generatedKotlinDir })` |
| GIVEN KMP jvm main compilation WHEN register after commonMain THEN platform task dependsOn metadata counterpart | Cross-target `dependsOn` chain on `faktGenerateMetadataCommonMain` |
| GIVEN KMP metadata commonMain compilation WHEN register THEN no dependsOn wiring added | `commonMain` early-return guard (chain root) |

#### `FaktGradleSubpluginFlagResolutionTest` (public `applyToCompilation`/`isApplicable` + TestKit for gradle properties)

| Test | Production behavior pinned |
|---|---|
| GIVEN flag true via extension AND JVM project WHEN applyToCompilation THEN returns single enabled false option | Extension `true` wins; in-process registrar told to exit early |
| GIVEN flag unset WHEN applyToCompilation on JVM THEN returns legacy options | Both unset → false; full legacy option payload (incl. `sourceSetContext`, `outputDir`) |
| GIVEN flag true via extension AND KMP project WHEN applyToCompilation THEN returns legacy options | `isCacheCorrectPathSupported` KMP veto |
| GIVEN JVM test compilation WHEN isApplicable THEN returns false | No FaktGenerateTask for test compilations (skipped at the `isApplicable` seam) |
| GIVEN gradle property true and extension unset WHEN building THEN faktGenerateJvmMain registered | Property fallback wins when extension unset (TestKit) |
| GIVEN gradle property yes WHEN building THEN treated as false and no faktGenerate task | `toBooleanStrictOrNull` — malformed value → false (TestKit) |
| GIVEN gradle property empty string WHEN building THEN treated as false and no faktGenerate task | Empty value → false, no crash (TestKit) |
| GIVEN extension false and gradle property true WHEN building THEN property wins and task registered | Documented asymmetry: extension `false` does not veto property `true` (TestKit) |

#### `FaktPluginExtensionDefaultsTest`

| Test | Production behavior pinned |
|---|---|
| GIVEN plugin applied WHEN reading logLevel THEN defaults to INFO | `logLevel` convention |
| GIVEN plugin applied WHEN reading enableMutableFakes THEN defaults to false | `enableMutableFakes` convention |
| GIVEN plugin applied WHEN reading useGradleTestFixtures THEN defaults to false | `useGradleTestFixtures` convention |
| GIVEN plugin applied WHEN reading collectFrom THEN is not present | Generator mode is the default mode |

(`enabled`, `enableCallHistory`, `useExperimentalGenerateTask` defaults were already pinned by existing suites — not duplicated.)

#### `SourceSetConfiguratorJvmTest`

| Test | Production behavior pinned |
|---|---|
| GIVEN JVM project without test fixtures WHEN configureSourceSets THEN compileTestKotlin includes generated test dir | JVM branch wires `generated/fakt/test/kotlin` into test compile tasks |
| GIVEN JVM project WHEN configureSourceSets THEN compileKotlin main does NOT include generated dir | `isTestTask` excludes main compilations |
| GIVEN useTestFixtures true AND java-test-fixtures applied WHEN configureSourceSets THEN testFixtures java srcDir includes generated dir | testFixtures happy path |
| GIVEN useTestFixtures true AND java-test-fixtures NOT applied WHEN configureSourceSets THEN completes without error | Null-safe no-op when the plugin is missing |
| GIVEN useTestFixtures true WHEN configureSourceSets THEN JVM test task wiring is skipped | Early return short-circuits default test wiring |

### Test infrastructure notes

- New helpers in `TestHelpers.kt`: `createJvmProject`, `Project.jvmCompilation`, `Project.kmpCompilation` — real `KotlinCompilation` instances under `ProjectBuilder` (the minimal fakes throw on members `register` dereferences).
- The gradle-property cases use TestKit synthetic builds (following the `FaktGenerateTaskTest` fixture style) because `ProjectBuilder` cannot inject Gradle properties; they only run `tasks --all` — configuration-time probing, never task execution.

## Related Issue
Refs #79

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build (test-only)

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] Static analysis: `./gradlew detekt`
- [x] API check: `./gradlew apiCheck`
- [x] Tests added/updated and passing: `./gradlew :gradle-plugin:test`
- [x] Configuration cache clean: `./gradlew --configuration-cache :gradle-plugin:test`
- [x] No breaking changes (test-only, no production changes)

## Additional Context

Red-green discipline: each test was verified to fail by temporarily mutating its pinned production seam (naming, guards, filters, `maybeCreate`, strict boolean parse, KMP veto, option payload) and reverting — five mutation rounds for the wiring suite, three for flag resolution, two for the source-set configurator, one for extension defaults.