### PR TITLE
feat(gradle): generate cache-correct KMP fakes via the commonMain producer

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
@@ -28,15 +28,23 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkerExecutor
 
+/** Heap ceiling for the forked codegen worker JVM. Generous enough for K2 over a large module. */
+private const val WORKER_MAX_HEAP: String = "1g"
+
+/** Metaspace ceiling for the forked worker JVM — `kotlin-compiler-embeddable` is class-heavy. */
+private const val WORKER_METASPACE_ARG: String = "-XX:MaxMetaspaceSize=512m"
+
 /**
  * Generates Fakt's `Fake<X>Impl.kt` files into a declared `@OutputDirectory` from outside
  * `compileKotlin*`. Solves issue #79: when Gradle's build cache restores `compileKotlin*`, the
  * generated `.kt` files come back too because they're now real task outputs rather than side-effect
  * writes.
  *
- * The task hosts `kotlin-compiler-embeddable` in an isolated [WorkerExecutor.classLoaderIsolation]
- * worker so the daemon doesn't carry the compiler classpath and so static state inside the FIR
- * pipeline can't leak across invocations. The reference architecture is KSP2's `KspAATask`.
+ * The task hosts `kotlin-compiler-embeddable` in an isolated [WorkerExecutor.processIsolation]
+ * worker so the daemon doesn't carry the compiler classpath, so static state inside the FIR
+ * pipeline can't leak across invocations, and so the compiler's metaspace footprint stays in a
+ * forked JVM that many concurrent producer tasks don't share. The reference architecture is KSP2's
+ * `KspAATask`.
  *
  * Caching semantics (path sensitivity, classpath normalization, output split, local state) are
  * documented on each annotated property. For KMP, the task runs in producer mode (writes
@@ -131,8 +139,23 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
 
     @TaskAction
     public fun generate() {
+        // Process isolation forks a pooled worker JVM that hosts `kotlin-compiler-embeddable` in
+        // its
+        // own metaspace, instead of loading the compiler into the Gradle daemon. On a multi-module
+        // KMP build many producer tasks run concurrently; under classloader isolation their
+        // parallel
+        // K2 invocations share the daemon's metaspace and exhaust it (`OutOfMemoryError:
+        // Metaspace`).
+        // The fork is reused across tasks with identical options, so the JVM-startup cost is paid
+        // once per pooled worker, not per task.
         val queue =
-            workers.classLoaderIsolation { spec -> spec.classpath.from(faktWorkerClasspath) }
+            workers.processIsolation { spec ->
+                spec.classpath.from(faktWorkerClasspath)
+                spec.forkOptions { options ->
+                    options.maxHeapSize = WORKER_MAX_HEAP
+                    options.jvmArgs(WORKER_METASPACE_ARG)
+                }
+            }
         queue.submit(FaktCodegenWorkAction::class.java) { params ->
             params.sources.from(sources)
             params.compileClasspath.from(compileClasspath)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
@@ -66,7 +66,7 @@ internal object FaktGenerateTaskWiring {
                 task.sources.from(
                     kotlinCompilation.allKotlinSourceSets.map { sourceSet -> sourceSet.kotlin }
                 )
-                task.compileClasspath.from(kotlinCompilation.compileDependencyFiles)
+                task.compileClasspath.from(commonProducerClasspath(project, kotlinCompilation))
                 task.faktWorkerClasspath.from(workerClasspath)
                 task.faktCompilerClasspath.from(compilerClasspath)
                 task.sourceSetContextJson.set(placeholderJson)
@@ -127,6 +127,35 @@ internal object FaktGenerateTaskWiring {
                     ?: project.tasks.findByName("faktGenerateCommonMain")
             if (commonTask != null) task.dependsOn(commonTask)
         }
+    }
+
+    /**
+     * Compile classpath for the worker. For a KMP `commonMain` producer the worker drives
+     * `K2JVMCompiler`, which needs a JVM-resolvable classpath — the JVM (or Android) target's
+     * `main` compile dependencies, which carry the JVM stdlib plus the JVM variant of every project
+     * and external dependency. `commonMain`'s own `compileDependencyFiles` are common `.klib`s that
+     * the JVM compiler can't read, so they are not used here. Every other compilation uses its own
+     * dependencies unchanged.
+     */
+    private fun commonProducerClasspath(
+        project: Project,
+        kotlinCompilation: KotlinCompilation<*>,
+    ): Any {
+        if (kotlinCompilation.defaultSourceSet.name == "commonMain") {
+            val jvmMain =
+                project.extensions
+                    .findByType(KotlinMultiplatformExtension::class.java)
+                    ?.targets
+                    ?.firstOrNull { target ->
+                        target.platformType.name.lowercase().let {
+                            it == "jvm" || it == "androidjvm"
+                        }
+                    }
+                    ?.compilations
+                    ?.findByName("main")
+            if (jvmMain != null) return jvmMain.compileDependencyFiles
+        }
+        return kotlinCompilation.compileDependencyFiles
     }
 
     /** Locate the [FaktGradleSubplugin] instance applied to [project] to call its helpers. */

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -14,6 +14,18 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
 /**
+ * Platforms the cache-correct worker can drive in-process. `K2JVMCompiler` ships in
+ * `kotlin-compiler-embeddable`; `K2NativeCompiler` does not, so only JVM and Android JVM targets
+ * are drivable today.
+ */
+private fun isDrivablePlatform(platformTypeName: String): Boolean =
+    when (platformTypeName.lowercase()) {
+        "jvm",
+        "androidjvm" -> true
+        else -> false
+    }
+
+/**
  * Gradle plugin for Fakt compiler plugin integration.
  *
  * This is the main entry point that bridges Gradle build system with the Fakt compiler plugin. It
@@ -91,6 +103,9 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         internal const val COMPILER_CLASSPATH_CONFIGURATION: String = "faktCompiler"
         internal const val GRADLE_PROPERTY_FLAG: String = "fakt.useExperimentalGenerateTask"
 
+        /** KGP metadata compilation whose default source set is `commonMain`. */
+        private const val COMMON_MAIN_COMPILATION: String = "commonMain"
+
         /**
          * Sentinel substituted into [SourceSetContext.outputDirectory] /
          * [SourceSetContext.commonTestOutputDirectory] when the JSON is stored as a task `@Input` —
@@ -129,22 +144,14 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                 // GENERATOR MODE: Generate fakes from @Fake annotations
                 target.logger.info("Fakt: Generator mode enabled - generating fakes")
 
-                val isKmp =
-                    target.extensions.findByType(
-                        org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java
-                    ) != null
                 val useTestFixtures = resolveTestFixturesMode(target, extension)
-                if (resolveExperimentalGenerateTaskFlag(target, extension) && !isKmp) {
+                if (resolveExperimentalGenerateTaskFlag(target, extension)) {
                     target.logger.info(
                         "Fakt: useExperimentalGenerateTask=true — registering FaktGenerateTask " +
                             "per compilation; the in-process compiler-plugin path stays disabled."
                     )
                     ensureFaktConfigurations(target)
                 } else {
-                    // Legacy in-process path. Also taken when the flag is on but the project is
-                    // KMP — the cache-correct worker only drives K2JVMCompiler, which can't
-                    // compile metadata/native, so KMP falls through to the legacy wiring
-                    // unchanged.
                     val configurator = SourceSetConfigurator(target, useTestFixtures)
                     configurator.configureSourceSets()
                 }
@@ -343,43 +350,82 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
             "Fakt: Applying compiler plugin to compilation ${kotlinCompilation.name}"
         )
 
-        if (
-            resolveExperimentalGenerateTaskFlag(project, extension) &&
-                isCacheCorrectPathSupported(kotlinCompilation)
-        ) {
-            // Side-effect: register FaktGenerateTask + wire its @OutputDirectory into the
-            // matching test source set. Returns `enabled=false` so the in-process compiler
-            // plugin (still loaded by KGP into compileKotlin*) skips registration — generation
-            // happens in our task instead. Empty list isn't enough: FaktCompilerPluginRegistrar
-            // defaults `enabled` to true and would explode when sourceSetContext is missing.
+        val decision =
+            if (resolveExperimentalGenerateTaskFlag(project, extension)) {
+                cacheCorrectDecision(kotlinCompilation)
+            } else {
+                CacheCorrectDecision.LEGACY
+            }
+
+        // REGISTER_PRODUCER drives generation from a FaktGenerateTask and disables the in-process
+        // plugin. DISABLE_IN_PROCESS (KMP platform mains) also disables it — the common producer
+        // already owns those fakes, and generating them again would surface as duplicate `.kt` /
+        // Redeclaration in shared test sets. Both return `enabled=false`; an empty list isn't
+        // enough
+        // because FaktCompilerPluginRegistrar defaults `enabled` to true and would explode when the
+        // sourceSetContext option is missing.
+        if (decision == CacheCorrectDecision.REGISTER_PRODUCER) {
             FaktGenerateTaskWiring.register(project, kotlinCompilation, extension)
+        }
+        if (decision != CacheCorrectDecision.LEGACY) {
             return project.provider { listOf(SubpluginOption(key = "enabled", value = "false")) }
         }
 
         return project.provider { legacyInProcessOptions(project, kotlinCompilation, extension) }
     }
 
+    /** How [applyToCompilation] should treat a compilation under the cache-correct flag. */
+    private enum class CacheCorrectDecision {
+        /** Drive `K2JVMCompiler` from a `FaktGenerateTask` for this compilation. */
+        REGISTER_PRODUCER,
+        /** Suppress the in-process plugin; another task already owns this compilation's fakes. */
+        DISABLE_IN_PROCESS,
+        /** Cache-correct path can't own this compilation; use the in-process plugin. */
+        LEGACY,
+    }
+
     /**
-     * The cache-correct worker drives `K2JVMCompiler` reflectively, so it can only analyse JVM
-     * bytecode-producing compilations. Two further constraints narrow the scope:
-     * 1. **Platform.** KMP metadata, Native, JS and Wasm compilations need their own K2 drivers
-     *    (`K2MetadataCompiler` et al.) plus matching common/native stdlib classpaths, which the
-     *    worker does not provide.
-     * 2. **KMP source-set inheritance.** Even on a JVM target inside a KMP project, the `jvmMain`
-     *    compilation's analysis source set is `jvmMain + commonMain` (KGP attaches parent source
-     *    sets). The task would generate fakes for `commonMain` `@Fake` interfaces too, conflicting
-     *    with the legacy in-process path that handles `compileKotlinMetadata`. Disabling the legacy
-     *    path entirely under the flag isn't safe yet (no `K2MetadataCompiler` producer) — so for
-     *    now KMP projects stay on legacy across the board.
+     * The cache-correct worker drives `K2JVMCompiler` reflectively. For a single-platform JVM
+     * project it owns the `main` compilation outright. For a KMP project it drives the JVM compiler
+     * once over `commonMain` (multiplatform mode) to produce platform-agnostic common fakes; every
+     * target's test compilation then consumes that one generated directory as ordinary source, so
+     * the Native/JS compilers never run Fakt. Platform `*Main` compilations therefore only need the
+     * in-process plugin suppressed — their common fakes already exist.
      *
-     * Pure JVM Gradle projects (no `KotlinMultiplatformExtension`) take the cache-correct path.
+     * Native/JS/Wasm cannot be driven in-process (`K2NativeCompiler` is not on the embeddable
+     * classpath), so a `@Fake` declared directly in a platform main source set is not yet handled
+     * on this path; that case stays a documented limitation.
      */
-    private fun isCacheCorrectPathSupported(kotlinCompilation: KotlinCompilation<*>): Boolean {
-        val platform = kotlinCompilation.target.platformType.name.lowercase()
-        if (platform != "jvm" && platform != "androidjvm") return false
-        return kotlinCompilation.project.extensions.findByType(
-            org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java
-        ) == null
+    private fun cacheCorrectDecision(
+        kotlinCompilation: KotlinCompilation<*>
+    ): CacheCorrectDecision {
+        val kmp =
+            kotlinCompilation.project.extensions.findByType(
+                org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java
+            )
+
+        // The metadata target exposes two compilations over the same `commonMain` sources: the
+        // per-source-set `commonMain` compilation and a legacy `main` compilation. Both report
+        // `defaultSourceSet == commonMain`, so match on the compilation name to register exactly
+        // one
+        // producer — registering both would wire duplicate generated `.kt` into `commonTest` and
+        // fail with `Redeclaration`. The common producer drives K2JVMCompiler over `commonMain`, so
+        // it needs a JVM-resolvable classpath; without a JVM/Android target the whole project stays
+        // on legacy. Every other KMP compilation (legacy metadata `main`, platform `*Main`) only
+        // needs the in-process plugin suppressed — the common producer already owns those fakes.
+        return when {
+            kmp == null ->
+                if (isDrivablePlatform(kotlinCompilation.target.platformType.name)) {
+                    CacheCorrectDecision.REGISTER_PRODUCER
+                } else {
+                    CacheCorrectDecision.LEGACY
+                }
+            kmp.targets.none { isDrivablePlatform(it.platformType.name) } ->
+                CacheCorrectDecision.LEGACY
+            kotlinCompilation.name == COMMON_MAIN_COMPILATION ->
+                CacheCorrectDecision.REGISTER_PRODUCER
+            else -> CacheCorrectDecision.DISABLE_IN_PROCESS
+        }
     }
 
     /** Original in-process subplugin option payload, untouched. */

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
@@ -92,7 +92,32 @@ class FaktGradleSubpluginFlagResolutionTest {
     }
 
     @Test
-    fun `GIVEN flag true via extension AND KMP project WHEN applyToCompilation THEN returns legacy options`() {
+    fun `GIVEN flag true AND KMP commonMain WHEN applyToCompilation THEN registers producer and returns enabled false`() {
+        val project = createKmpProject()
+        project.getKotlinExtension().jvm()
+        project.getKotlinExtension().linuxX64()
+        project.faktExtension().useExperimentalGenerateTask.set(true)
+        project.evaluate()
+
+        val options =
+            project
+                .faktSubplugin()
+                .applyToCompilation(project.kmpCompilation("metadata", "commonMain"))
+                .get()
+
+        assertEquals(
+            "false",
+            options.single { it.key == "enabled" }.value,
+            "commonMain generation moves to the producer task; the in-process plugin stays off.",
+        )
+        assertTrue(
+            project.tasks.names.any { it.startsWith("faktGenerate") },
+            "The commonMain producer task must be registered for the cache-correct KMP path.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag true AND KMP platform main WHEN applyToCompilation THEN disables in-process plugin`() {
         val project = createKmpProject()
         project.getKotlinExtension().jvm()
         project.faktExtension().useExperimentalGenerateTask.set(true)
@@ -101,10 +126,33 @@ class FaktGradleSubpluginFlagResolutionTest {
         val options =
             project.faktSubplugin().applyToCompilation(project.kmpCompilation("jvm", "main")).get()
 
+        assertEquals(
+            1,
+            options.size,
+            "A platform main compilation only gets enabled=false — the common producer already " +
+                "owns its fakes; keys: ${options.map { it.key }}",
+        )
+        assertEquals("enabled", options.single().key)
+        assertEquals("false", options.single().value)
+    }
+
+    @Test
+    fun `GIVEN flag true AND KMP without a drivable target WHEN applyToCompilation THEN returns legacy options`() {
+        val project = createKmpProject()
+        project.getKotlinExtension().linuxX64()
+        project.faktExtension().useExperimentalGenerateTask.set(true)
+        project.evaluate()
+
+        val options =
+            project
+                .faktSubplugin()
+                .applyToCompilation(project.kmpCompilation("linuxX64", "main"))
+                .get()
+
         assertTrue(
             options.any { it.key == "sourceSetContext" },
-            "KMP must veto the cache-correct path — the worker only drives K2JVMCompiler; " +
-                "keys: ${options.map { it.key }}",
+            "Without a JVM/Android target the common producer can't run (no JVM classpath), so the " +
+                "project stays on the in-process path; keys: ${options.map { it.key }}",
         )
         assertTrue(project.tasks.names.none { it.startsWith("faktGenerate") })
     }


### PR DESCRIPTION
## Description

Lifts the KMP veto on the cache-correct generation path (issue #79), so a warm Gradle build cache
never produces empty/missing fakes for Kotlin Multiplatform projects.

`applyToCompilation` now classifies each compilation:

| Compilation | Decision |
|---|---|
| Single-platform JVM `main` | Register `FaktGenerateTask`, in-process plugin off |
| KMP `commonMain` (metadata) | Register the common producer, in-process plugin off |
| KMP legacy metadata `main`, platform `*Main` | Suppress in-process plugin (producer owns the fakes) |
| KMP with no JVM/Android target | Stay on the legacy in-process path |

The common producer drives `K2JVMCompiler` over `commonMain` once (multiplatform mode) and writes
platform-agnostic fakes to a declared `@OutputDirectory`; every target's test compilation — including
Native/JS — consumes that directory as ordinary source, so the Native/JS compilers never run Fakt.

### Why these specifics
- **Two commonMain compilations.** KGP's metadata target exposes both a per-source-set `commonMain`
  compilation and a legacy `main` compilation over the same sources. Registering a producer for both
  wires duplicate `.kt` into `commonTest` (`Redeclaration`), so the producer is registered only for the
  `commonMain`-named one.
- **Classpath.** The producer compiles against the JVM target's `main.compileDependencyFiles` (JVM stdlib
  + JVM variants), not the commonMain `.klib`s the JVM compiler can't read. Hence the JVM/Android-target
  requirement.
- **`processIsolation`.** A multi-module KMP build runs many producer tasks concurrently; under
  classloader isolation their parallel K2 invocations exhausted the Gradle daemon's metaspace
  (`OutOfMemoryError: Metaspace`). A pooled worker fork (1g heap, 512m metaspace) isolates the compiler.
- **Collector mode is fixed for free.** `FakeCollectorTask` already wires `sourceFakeRoots` from
  `FaktGenerateTask.generatedKotlinDir` and caches only when that input is present; lifting the gate
  populates it.

## Related Issue
Refs #79

## Type of Change
- [x] New feature

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] Static analysis: `./gradlew detekt`
- [x] API check passing (no public surface change): `./gradlew apiCheck`
- [x] Tests added/updated and passing: `./gradlew :gradle-plugin:test` (134 tests; 3 new classifier tests)
- [x] Configuration cache clean: `./gradlew --configuration-cache :gradle-plugin:test`

## Verification

**#79 reproducer (warm cache → clean → `--build-cache` rebuild):**
- `kmp-multi-module` (collector): after `clean` (0 fakes on disk), **46 fakes restored** via **11
  `faktGenerateMetadataCommonMain` tasks reporting FROM-CACHE**.
- `fake-publishing` (collector): 6 fakes restored via 1 FROM-CACHE producer.

**Flag ON (acceptance):** `jvm-single-module` (`test`), `kmp-single-module` (JVM + iOS test compile +
`jvmTest`), `kmp-multi-module` (JVM + iOS), `fake-publishing`.

**Flag OFF (legacy regression):** `jvm-single-module`, `kmp-single-module`, `kmp-multi-module` — all
unchanged and green.

## Additional Context

A `@Fake` declared directly in a non-drivable platform main source set (e.g. `iosMain`) is not yet
generated on this path and stays a documented limitation, behind the opt-in
`fakt.useExperimentalGenerateTask` flag (default off). The loud diagnostic for that case and the
automated CI regression contract are tracked as follow-ups.