### PR TITLE
fix(gradle): forward enableCallHistory/enableMutableFakes to codegen worker

### DIFF
--- a/.claude/docs/implementation/architecture/metadata-producer-fir-emission.md
+++ b/.claude/docs/implementation/architecture/metadata-producer-fir-emission.md
@@ -295,10 +295,12 @@ CI presence checks continue to lock it.
   mode is ever wired, `MetadataCacheManager.tryLoadCache` returns `true` for **every** declaration once
   loaded, and the checker's early return would skip analysis (and FIR emission) of the platform's own
   source declarations. Do not wire consumer mode without fixing the short-circuit to be per-ClassId.
-- **Worker options gap (pre-existing):** the worker forwards only 4 plugin options; `enableCallHistory`/
-  `enableMutableFakes` extension settings are not among them. The FIR emitter resolves modes exactly as
-  the IR path does, so FIR/IR parity holds — the worker-vs-legacy defaults gap is a separate issue to
-  file, not fixed here.
+- **Worker options gap (fixed, issue #112):** the worker now forwards 6 plugin options — the original
+  `enabled`/`logLevel`/`outputDir`/`sourceSetContext` plus the `enableCallHistory`/`enableMutableFakes`
+  extension defaults. `FaktGenerateTask` carries the latter two as `@Input`s so they participate in the
+  cache key, and `FaktGenerateTaskWiring.register` sources them from the `fakt { }` extension. The FIR
+  emitter already resolved modes exactly as the IR path does, so FIR/IR parity was never the gap — it was
+  purely the worker-vs-legacy option payload, now closed.
 - **Out of scope:** flipping `useExperimentalGenerateTask` default (P8); removing the legacy path (P9);
   cache-correct platform-declared fakes for Native/JS/Wasm; `actual typealias` and `@Fake`-on-expect
   scenarios (checker rejects `FAKE_CANNOT_BE_EXPECT` by design).

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -41,6 +41,8 @@ public abstract class com/rsicarelli/fakt/gradle/FaktGenerateTask : org/gradle/a
 	public abstract fun getCommonFirMetadata ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getCommonKlibClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getCompileClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getEnableCallHistory ()Lorg/gradle/api/provider/Property;
+	public abstract fun getEnableMutableFakes ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFaktCompilerClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getFaktVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFaktWorkerClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
@@ -127,6 +127,22 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
 
     @get:Input public abstract val logLevel: Property<LogLevel>
 
+    /**
+     * Extension-level default for call-history generation (`fakt { enableCallHistory }`). Forwarded
+     * to the compiler plugin so the worker path produces the same fakes as the legacy in-process
+     * path. `@Input` so a change to the default invalidates cached outputs; `@Optional` because the
+     * compiler falls back to its own default (`true`) when the option is absent.
+     */
+    @get:Input @get:Optional public abstract val enableCallHistory: Property<Boolean>
+
+    /**
+     * Extension-level default for mutable-fake generation (`fakt { enableMutableFakes }`). Forwarded
+     * to the compiler plugin so the worker path produces the same fakes as the legacy in-process
+     * path. `@Input` so a change to the default invalidates cached outputs; `@Optional` because the
+     * compiler falls back to its own default (`false`) when the option is absent.
+     */
+    @get:Input @get:Optional public abstract val enableMutableFakes: Property<Boolean>
+
     /** Imports forced into every generated file (e.g. user-extension imports). */
     @get:Input public abstract val imports: ListProperty<String>
 
@@ -189,6 +205,8 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
             params.sourceSetContextJson.set(sourceSetContextJson)
             params.faktVersion.set(faktVersion)
             params.logLevel.set(logLevel)
+            params.enableCallHistory.set(enableCallHistory)
+            params.enableMutableFakes.set(enableMutableFakes)
             params.imports.set(imports)
             params.commonFirMetadata.set(commonFirMetadata)
             params.generatedKotlinDir.set(generatedKotlinDir)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTask.kt
@@ -136,10 +136,10 @@ public abstract class FaktGenerateTask @Inject constructor(private val workers: 
     @get:Input @get:Optional public abstract val enableCallHistory: Property<Boolean>
 
     /**
-     * Extension-level default for mutable-fake generation (`fakt { enableMutableFakes }`). Forwarded
-     * to the compiler plugin so the worker path produces the same fakes as the legacy in-process
-     * path. `@Input` so a change to the default invalidates cached outputs; `@Optional` because the
-     * compiler falls back to its own default (`false`) when the option is absent.
+     * Extension-level default for mutable-fake generation (`fakt { enableMutableFakes }`).
+     * Forwarded to the compiler plugin so the worker path produces the same fakes as the legacy
+     * in-process path. `@Input` so a change to the default invalidates cached outputs; `@Optional`
+     * because the compiler falls back to its own default (`false`) when the option is absent.
      */
     @get:Input @get:Optional public abstract val enableMutableFakes: Property<Boolean>
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
@@ -121,6 +121,8 @@ internal object FaktGenerateTaskWiring {
                 task.sourceSetContextJson.set(placeholderJson)
                 task.faktVersion.set(FaktGradleSubplugin.PLUGIN_VERSION)
                 task.logLevel.set(extension.logLevel)
+                task.enableCallHistory.set(extension.enableCallHistory)
+                task.enableMutableFakes.set(extension.enableMutableFakes)
                 task.imports.set(emptyList())
                 task.generatedKotlinDir.set(outputDir)
                 task.scratchDir.set(scratchDir)

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
@@ -30,6 +30,8 @@ internal interface FaktCodegenWorkParameters : WorkParameters {
     val sourceSetContextJson: Property<String>
     val faktVersion: Property<String>
     val logLevel: Property<LogLevel>
+    val enableCallHistory: Property<Boolean>
+    val enableMutableFakes: Property<Boolean>
     val imports: ListProperty<String>
     val commonFirMetadata: RegularFileProperty
     val generatedKotlinDir: DirectoryProperty
@@ -96,6 +98,8 @@ internal abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParame
                 scratchOutputDir = params.scratchDir.asFile.get(),
                 sourceSetContextBase64 = encodeContext(sourceSetContext),
                 logLevel = params.logLevel.getOrElse(LogLevel.QUIET),
+                enableCallHistory = params.enableCallHistory.getOrElse(true),
+                enableMutableFakes = params.enableMutableFakes.getOrElse(false),
             )
         )
     }
@@ -184,6 +188,8 @@ internal abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParame
         val scratchOutputDir: File,
         val sourceSetContextBase64: String,
         val logLevel: LogLevel,
+        val enableCallHistory: Boolean,
+        val enableMutableFakes: Boolean,
     )
 
     private fun invokeK2(call: K2Invocation) {
@@ -296,6 +302,8 @@ internal abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParame
                 "${FaktPluginOptions.LOG_LEVEL}=${call.logLevel.name}",
                 "${FaktPluginOptions.OUTPUT_DIR}=${call.outputDir.absolutePath}",
                 "${FaktPluginOptions.SOURCE_SET_CONTEXT}=${call.sourceSetContextBase64}",
+                "${FaktPluginOptions.ENABLE_CALL_HISTORY}=${call.enableCallHistory}",
+                "${FaktPluginOptions.ENABLE_MUTABLE_FAKES}=${call.enableMutableFakes}",
             )
         bridge.setOnArgs(args, "setPluginOptions", Array<String>::class.java, pluginOptions)
     }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/FaktCodegenWorkAction.kt
@@ -297,14 +297,18 @@ internal abstract class FaktCodegenWorkAction : WorkAction<FaktCodegenWorkParame
             call.pluginJars.map { it.absolutePath }.toTypedArray(),
         )
         val pluginOptions =
-            arrayOf(
-                "${FaktPluginOptions.ENABLED}=true",
-                "${FaktPluginOptions.LOG_LEVEL}=${call.logLevel.name}",
-                "${FaktPluginOptions.OUTPUT_DIR}=${call.outputDir.absolutePath}",
-                "${FaktPluginOptions.SOURCE_SET_CONTEXT}=${call.sourceSetContextBase64}",
-                "${FaktPluginOptions.ENABLE_CALL_HISTORY}=${call.enableCallHistory}",
-                "${FaktPluginOptions.ENABLE_MUTABLE_FAKES}=${call.enableMutableFakes}",
+            FaktPluginOptions.payload(
+                logLevel = call.logLevel.name,
+                outputDir = call.outputDir.absolutePath,
+                sourceSetContextBase64 = call.sourceSetContextBase64,
+                enableCallHistory = call.enableCallHistory,
+                enableMutableFakes = call.enableMutableFakes,
             )
-        bridge.setOnArgs(args, "setPluginOptions", Array<String>::class.java, pluginOptions)
+        bridge.setOnArgs(
+            args,
+            "setPluginOptions",
+            Array<String>::class.java,
+            pluginOptions.toTypedArray(),
+        )
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/K2CompilerBridge.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/K2CompilerBridge.kt
@@ -54,6 +54,8 @@ internal object FaktPluginOptions {
     const val LOG_LEVEL = "${PREFIX}logLevel"
     const val OUTPUT_DIR = "${PREFIX}outputDir"
     const val SOURCE_SET_CONTEXT = "${PREFIX}sourceSetContext"
+    const val ENABLE_CALL_HISTORY = "${PREFIX}enableCallHistory"
+    const val ENABLE_MUTABLE_FAKES = "${PREFIX}enableMutableFakes"
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/K2CompilerBridge.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/K2CompilerBridge.kt
@@ -60,8 +60,8 @@ internal object FaktPluginOptions {
     /**
      * Builds the `-P` plugin-option payload forwarded to Fakt's `:compiler` plugin. Kept as a pure
      * function (no reflection, no compiler types) so the worker-vs-legacy option parity — including
-     * the [ENABLE_CALL_HISTORY] / [ENABLE_MUTABLE_FAKES] extension defaults dropped before issue
-     * #112 — is unit-testable without spinning up the forked worker.
+     * the [ENABLE_CALL_HISTORY] / [ENABLE_MUTABLE_FAKES] extension defaults dropped before
+     * issue #112 — is unit-testable without spinning up the forked worker.
      */
     fun payload(
         logLevel: String,

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/K2CompilerBridge.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/worker/K2CompilerBridge.kt
@@ -56,6 +56,28 @@ internal object FaktPluginOptions {
     const val SOURCE_SET_CONTEXT = "${PREFIX}sourceSetContext"
     const val ENABLE_CALL_HISTORY = "${PREFIX}enableCallHistory"
     const val ENABLE_MUTABLE_FAKES = "${PREFIX}enableMutableFakes"
+
+    /**
+     * Builds the `-P` plugin-option payload forwarded to Fakt's `:compiler` plugin. Kept as a pure
+     * function (no reflection, no compiler types) so the worker-vs-legacy option parity — including
+     * the [ENABLE_CALL_HISTORY] / [ENABLE_MUTABLE_FAKES] extension defaults dropped before issue
+     * #112 — is unit-testable without spinning up the forked worker.
+     */
+    fun payload(
+        logLevel: String,
+        outputDir: String,
+        sourceSetContextBase64: String,
+        enableCallHistory: Boolean,
+        enableMutableFakes: Boolean,
+    ): List<String> =
+        listOf(
+            "$ENABLED=true",
+            "$LOG_LEVEL=$logLevel",
+            "$OUTPUT_DIR=$outputDir",
+            "$SOURCE_SET_CONTEXT=$sourceSetContextBase64",
+            "$ENABLE_CALL_HISTORY=$enableCallHistory",
+            "$ENABLE_MUTABLE_FAKES=$enableMutableFakes",
+        )
 }
 
 /**

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskTest.kt
@@ -8,6 +8,7 @@ import com.rsicarelli.fakt.compiler.fir.cache.MetadataCacheSerializer
 import java.io.File
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
@@ -253,10 +254,57 @@ class FaktGenerateTaskTest {
             .withArguments(*arguments, "--stacktrace")
             .build()
 
+    @Test
+    fun `GIVEN enableCallHistory=false WHEN running faktGenerate THEN generated fake omits call-history members`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(
+            projectDir,
+            fixtureSource = SINGLE_INTERFACE_FIXTURE,
+            enableCallHistory = false,
+        )
+
+        val result = runTask(projectDir, "faktGenerate")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":faktGenerate")?.outcome, result.output)
+        val content =
+            projectDir
+                .resolve("build/generated/fakt")
+                .walkTopDown()
+                .single { it.isFile && it.name == "FakeUserServiceImpl.kt" }
+                .readText()
+        assertFalse(
+            "greetCalls" in content,
+            "enableCallHistory=false must drop call-history members from the worker path; got:\n$content",
+        )
+    }
+
+    @Test
+    fun `GIVEN enableCallHistory default WHEN running faktGenerate THEN generated fake keeps call-history members`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(projectDir, fixtureSource = SINGLE_INTERFACE_FIXTURE)
+
+        val result = runTask(projectDir, "faktGenerate")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":faktGenerate")?.outcome, result.output)
+        val content =
+            projectDir
+                .resolve("build/generated/fakt")
+                .walkTopDown()
+                .single { it.isFile && it.name == "FakeUserServiceImpl.kt" }
+                .readText()
+        assertTrue(
+            "greetCalls" in content,
+            "call history is on by default; the worker path must still emit call-history members; got:\n$content",
+        )
+    }
+
     private fun setupProject(
         projectDir: File,
         fixtureSource: String,
         firMetadataFile: File? = null,
+        enableCallHistory: Boolean? = null,
     ) {
         projectDir
             .resolve("settings.gradle.kts")
@@ -271,7 +319,7 @@ class FaktGenerateTaskTest {
         projectDir.resolve("src/main/kotlin/fixture/Fixture.kt").writeText(fixtureSource)
         projectDir
             .resolve("build.gradle.kts")
-            .writeText(buildScriptForTask(projectDir, firMetadataFile))
+            .writeText(buildScriptForTask(projectDir, firMetadataFile, enableCallHistory))
     }
 
     private fun configureLocalBuildCache(projectDir: File, buildCacheDir: File) {
@@ -291,7 +339,11 @@ class FaktGenerateTaskTest {
             )
     }
 
-    private fun buildScriptForTask(projectDir: File, firMetadataFile: File? = null): String {
+    private fun buildScriptForTask(
+        projectDir: File,
+        firMetadataFile: File? = null,
+        enableCallHistory: Boolean? = null,
+    ): String {
         val outputDir = projectDir.resolve("build/generated/fakt/jvm/jvmTest/kotlin")
         // The stored context carries placeholder paths only — the worker overwrites
         // outputDirectory / commonTestOutputDirectory / metadataOutputPath / metadataCachePath at
@@ -343,6 +395,7 @@ class FaktGenerateTaskTest {
                 generatedKotlinDir.set(file("${outputDir.absolutePath.replace('\\', '/')}"))
                 scratchDir.set(layout.buildDirectory.dir("faktCaches/jvm/jvmTest"))
                 ${firMetadataFile?.let { "firMetadataFile.set(file(\"${it.absolutePath.replace('\\', '/')}\"))" } ?: ""}
+                ${enableCallHistory?.let { "enableCallHistory.set($it)" } ?: ""}
             }
 
             tasks.register("clean") { doLast { delete(layout.buildDirectory) } }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskTest.kt
@@ -300,11 +300,58 @@ class FaktGenerateTaskTest {
         )
     }
 
+    @Test
+    fun `GIVEN enableMutableFakes=true WHEN running faktGenerate THEN generated fake is mutable`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(
+            projectDir,
+            fixtureSource = SINGLE_INTERFACE_FIXTURE,
+            enableMutableFakes = true,
+        )
+
+        val result = runTask(projectDir, "faktGenerate")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":faktGenerate")?.outcome, result.output)
+        val content =
+            projectDir
+                .resolve("build/generated/fakt")
+                .walkTopDown()
+                .single { it.isFile && it.name == "FakeUserServiceImpl.kt" }
+                .readText()
+        assertTrue(
+            "fun modify(" in content && "@Volatile" in content,
+            "enableMutableFakes=true must make the worker path emit a mutable fake (modify + @Volatile); got:\n$content",
+        )
+    }
+
+    @Test
+    fun `GIVEN enableMutableFakes default WHEN running faktGenerate THEN generated fake is immutable`(
+        @TempDir projectDir: File
+    ) {
+        setupProject(projectDir, fixtureSource = SINGLE_INTERFACE_FIXTURE)
+
+        val result = runTask(projectDir, "faktGenerate")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":faktGenerate")?.outcome, result.output)
+        val content =
+            projectDir
+                .resolve("build/generated/fakt")
+                .walkTopDown()
+                .single { it.isFile && it.name == "FakeUserServiceImpl.kt" }
+                .readText()
+        assertFalse(
+            "fun modify(" in content,
+            "mutable fakes are off by default; the worker path must emit an immutable fake; got:\n$content",
+        )
+    }
+
     private fun setupProject(
         projectDir: File,
         fixtureSource: String,
         firMetadataFile: File? = null,
         enableCallHistory: Boolean? = null,
+        enableMutableFakes: Boolean? = null,
     ) {
         projectDir
             .resolve("settings.gradle.kts")
@@ -319,7 +366,14 @@ class FaktGenerateTaskTest {
         projectDir.resolve("src/main/kotlin/fixture/Fixture.kt").writeText(fixtureSource)
         projectDir
             .resolve("build.gradle.kts")
-            .writeText(buildScriptForTask(projectDir, firMetadataFile, enableCallHistory))
+            .writeText(
+                buildScriptForTask(
+                    projectDir,
+                    firMetadataFile,
+                    enableCallHistory,
+                    enableMutableFakes,
+                )
+            )
     }
 
     private fun configureLocalBuildCache(projectDir: File, buildCacheDir: File) {
@@ -343,6 +397,7 @@ class FaktGenerateTaskTest {
         projectDir: File,
         firMetadataFile: File? = null,
         enableCallHistory: Boolean? = null,
+        enableMutableFakes: Boolean? = null,
     ): String {
         val outputDir = projectDir.resolve("build/generated/fakt/jvm/jvmTest/kotlin")
         // The stored context carries placeholder paths only — the worker overwrites
@@ -396,6 +451,7 @@ class FaktGenerateTaskTest {
                 scratchDir.set(layout.buildDirectory.dir("faktCaches/jvm/jvmTest"))
                 ${firMetadataFile?.let { "firMetadataFile.set(file(\"${it.absolutePath.replace('\\', '/')}\"))" } ?: ""}
                 ${enableCallHistory?.let { "enableCallHistory.set($it)" } ?: ""}
+                ${enableMutableFakes?.let { "enableMutableFakes.set($it)" } ?: ""}
             }
 
             tasks.register("clean") { doLast { delete(layout.buildDirectory) } }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/worker/FaktPluginOptionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/worker/FaktPluginOptionsTest.kt
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.TestInstance
 /**
  * Pure unit coverage for the worker's `-P` plugin-option payload ([FaktPluginOptions.payload]).
  *
- * Guards the issue #112 fix: the cache-correct worker path must forward the
- * `enableCallHistory` / `enableMutableFakes` extension defaults alongside the original four options,
- * so it can't silently fall back to the compiler's own defaults the way it did before. This runs
- * without the forked worker or `kotlin-compiler-embeddable`, so a regression in the forwarded keys
- * or values fails fast instead of only surfacing in the slower TestKit suite.
+ * Guards the issue #112 fix: the cache-correct worker path must forward the `enableCallHistory` /
+ * `enableMutableFakes` extension defaults alongside the original four options, so it can't silently
+ * fall back to the compiler's own defaults the way it did before. This runs without the forked
+ * worker or `kotlin-compiler-embeddable`, so a regression in the forwarded keys or values fails
+ * fast instead of only surfacing in the slower TestKit suite.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FaktPluginOptionsTest {

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/worker/FaktPluginOptionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/worker/FaktPluginOptionsTest.kt
@@ -1,0 +1,107 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle.worker
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Pure unit coverage for the worker's `-P` plugin-option payload ([FaktPluginOptions.payload]).
+ *
+ * Guards the issue #112 fix: the cache-correct worker path must forward the
+ * `enableCallHistory` / `enableMutableFakes` extension defaults alongside the original four options,
+ * so it can't silently fall back to the compiler's own defaults the way it did before. This runs
+ * without the forked worker or `kotlin-compiler-embeddable`, so a regression in the forwarded keys
+ * or values fails fast instead of only surfacing in the slower TestKit suite.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktPluginOptionsTest {
+
+    @Test
+    fun `GIVEN option keys WHEN read THEN each carries the compiler plugin prefix`() {
+        val keys =
+            listOf(
+                FaktPluginOptions.ENABLED,
+                FaktPluginOptions.LOG_LEVEL,
+                FaktPluginOptions.OUTPUT_DIR,
+                FaktPluginOptions.SOURCE_SET_CONTEXT,
+                FaktPluginOptions.ENABLE_CALL_HISTORY,
+                FaktPluginOptions.ENABLE_MUTABLE_FAKES,
+            )
+
+        keys.forEach { key ->
+            assertTrue(
+                key.startsWith("plugin:com.rsicarelli.fakt:"),
+                "Option key must carry the Fakt compiler-plugin prefix: $key",
+            )
+        }
+        assertEquals(
+            "plugin:com.rsicarelli.fakt:enableCallHistory",
+            FaktPluginOptions.ENABLE_CALL_HISTORY,
+        )
+        assertEquals(
+            "plugin:com.rsicarelli.fakt:enableMutableFakes",
+            FaktPluginOptions.ENABLE_MUTABLE_FAKES,
+        )
+    }
+
+    @Test
+    fun `GIVEN codegen inputs WHEN building the payload THEN it forwards all six options in order`() {
+        val payload =
+            FaktPluginOptions.payload(
+                logLevel = "DEBUG",
+                outputDir = "/out/generated",
+                sourceSetContextBase64 = "BASE64==",
+                enableCallHistory = true,
+                enableMutableFakes = false,
+            )
+
+        assertEquals(
+            listOf(
+                "plugin:com.rsicarelli.fakt:enabled=true",
+                "plugin:com.rsicarelli.fakt:logLevel=DEBUG",
+                "plugin:com.rsicarelli.fakt:outputDir=/out/generated",
+                "plugin:com.rsicarelli.fakt:sourceSetContext=BASE64==",
+                "plugin:com.rsicarelli.fakt:enableCallHistory=true",
+                "plugin:com.rsicarelli.fakt:enableMutableFakes=false",
+            ),
+            payload,
+        )
+    }
+
+    @Test
+    fun `GIVEN call history disabled WHEN building the payload THEN the flag is forwarded as false`() {
+        val payload =
+            FaktPluginOptions.payload(
+                logLevel = "QUIET",
+                outputDir = "/out",
+                sourceSetContextBase64 = "ctx",
+                enableCallHistory = false,
+                enableMutableFakes = false,
+            )
+
+        assertTrue(
+            "plugin:com.rsicarelli.fakt:enableCallHistory=false" in payload,
+            "enableCallHistory=false must reach the compiler, not fall back to the true default; got: $payload",
+        )
+    }
+
+    @Test
+    fun `GIVEN mutable fakes enabled WHEN building the payload THEN the flag is forwarded as true`() {
+        val payload =
+            FaktPluginOptions.payload(
+                logLevel = "INFO",
+                outputDir = "/out",
+                sourceSetContextBase64 = "ctx",
+                enableCallHistory = true,
+                enableMutableFakes = true,
+            )
+
+        assertTrue(
+            "plugin:com.rsicarelli.fakt:enableMutableFakes=true" in payload,
+            "enableMutableFakes=true must reach the compiler, not fall back to the false default; got: $payload",
+        )
+    }
+}


### PR DESCRIPTION
## Description

Under `fakt.useExperimentalGenerateTask=true`, the cache-correct worker path
(`FaktCodegenWorkAction`) forwarded only four plugin options — `enabled`,
`logLevel`, `outputDir`, `sourceSetContext` — while the legacy in-process path
(`FaktGradleSubplugin.legacyInProcessOptions`) additionally forwards the
`enableCallHistory` / `enableMutableFakes` extension defaults. As a result a
project that set e.g. `fakt { enableCallHistory.set(false) }` got **different
generated fakes** depending on the flag: the worker silently fell back to the
compiler's own defaults. Per-declaration `@Fake(...)` arguments were unaffected
(resolved inside the compiler) — only the extension-level defaults were dropped.

This change carries the two settings all the way through the worker pipeline:

- `FaktGenerateTask` gains `enableCallHistory` / `enableMutableFakes` as
  `@Input @Optional` properties, so they participate in the build-cache key
  (a change to the default invalidates cached fakes).
- `FaktGenerateTaskWiring.register` sources both from the `fakt { }` extension.
- `FaktCodegenWorkParameters` / `FaktCodegenWorkAction` thread them through and
  forward them as `-P` options alongside the existing four. The payload is built
  by a new pure `FaktPluginOptions.payload(...)` so the forwarding is unit-testable
  without the forked worker.
- Doc §9 (`metadata-producer-fir-emission.md`) hazard note flipped from "gap" to
  "fixed".

FIR/IR parity is unaffected — the FIR emitter already resolved modes exactly like
the IR path; this was purely the worker-vs-legacy option payload.

## Related Issue
Fixes #112

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Tests added/updated: `FaktPluginOptionsTest` (pure unit, payload keys/values) and
  extended `FaktGenerateTaskTest` (TestKit) with `enableCallHistory` and
  `enableMutableFakes` on/off cases
- [ ] Code formatted / linter / detekt / tests run locally — **not run in this
  environment** (the Gradle 9.0.0 wrapper distribution is unreachable here); relying
  on this PR's CI (`development.yml`) to validate Spotless, tests, and the
  `-Pfakt.useExperimentalGenerateTask` sample matrix
- [x] Updated documentation (architecture doc §9)
- [x] No breaking changes

## Additional Context
Verification is delegated to CI because the Gradle 9 distribution could not be
fetched in the development sandbox. The added TestKit cases exercise the worker
end-to-end (asserting `*Calls` members / `modify` + `@Volatile` appear or disappear
per the extension default), and the sample matrix build under the experimental flag
is the end-to-end regression guard for the original reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2Vq21JLVBeqKq1bVtgtrG

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Vq21JLVBeqKq1bVtgtrG)_