### PR TITLE
chore(samples): enable experimental FaktGenerateTask for P8 dry-run

### DIFF
--- a/samples/android-single-module/gradle.properties
+++ b/samples/android-single-module/gradle.properties
@@ -14,3 +14,6 @@ kotlin.incremental=true
 # Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/fake-publishing/kmp-consumer/gradle.properties
+++ b/samples/fake-publishing/kmp-consumer/gradle.properties
@@ -10,3 +10,6 @@ org.gradle.configuration-cache=true
 # Kotlin settings
 kotlin.mpp.stability.nowarn=true
 kotlin.js.yarn=false
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/fake-publishing/kmp-publisher/gradle.properties
+++ b/samples/fake-publishing/kmp-publisher/gradle.properties
@@ -10,3 +10,6 @@ org.gradle.configuration-cache=true
 # Kotlin settings
 kotlin.mpp.stability.nowarn=true
 kotlin.js.yarn=false
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/jvm-single-module/gradle.properties
+++ b/samples/jvm-single-module/gradle.properties
@@ -10,3 +10,6 @@ org.gradle.parallel=true
 # Kotlin
 kotlin.code.style=official
 kotlin.incremental=true
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/jvm-test-fixtures/gradle.properties
+++ b/samples/jvm-test-fixtures/gradle.properties
@@ -10,3 +10,6 @@ org.gradle.parallel=true
 # Kotlin
 kotlin.code.style=official
 kotlin.incremental=true
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/kmp-benchmark/gradle.properties
+++ b/samples/kmp-benchmark/gradle.properties
@@ -22,3 +22,5 @@ kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=256m
 
 # Kotlin Native
 kotlin.native.ignoreDisabledTargets=true
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/kmp-multi-module/gradle.properties
+++ b/samples/kmp-multi-module/gradle.properties
@@ -28,3 +28,6 @@ kotlin.native.cacheKind=none
 # Disable unnecessary features for samples
 android.useAndroidX=false
 android.enableJetifier=false
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/kmp-multi-target/gradle.properties
+++ b/samples/kmp-multi-target/gradle.properties
@@ -22,3 +22,6 @@ kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=256m
 
 # Kotlin Native
 kotlin.native.ignoreDisabledTargets=true
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/kmp-no-jvm/gradle.properties
+++ b/samples/kmp-no-jvm/gradle.properties
@@ -22,3 +22,6 @@ kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=256m
 
 # Kotlin Native
 kotlin.native.ignoreDisabledTargets=true
+
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true

--- a/samples/kmp-single-module/gradle.properties
+++ b/samples/kmp-single-module/gradle.properties
@@ -22,3 +22,5 @@ kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=256m
 
 # Kotlin Native
 kotlin.native.ignoreDisabledTargets=true
+# P8 dry-run: exercise the cache-correct FaktGenerateTask path (issue #79)
+fakt.useExperimentalGenerateTask=true


### PR DESCRIPTION
## Description

**P8 readiness probe — not intended to merge as-is.** Sets `fakt.useExperimentalGenerateTask=true` in every sample's `gradle.properties` so the whole CI sample matrix runs against the cache-correct `FaktGenerateTask` path. The point is to let CI tell us whether anything still breaks with the flag on everywhere, now that the four P8 assessment items are fixed:

- ✅ Blocker 1 — Android per-variant collision + gap 3 (`useGradleTestFixtures`) — #115
- ✅ Blocker 2 — flag-migration `Redeclaration` self-heal — #116
- ✅ Gap 4 — `cache-correctness-check.sh` warm-phase false negative — #117

10 sample roots flipped: `jvm-single-module`, `android-single-module`, `jvm-test-fixtures`, `kmp-single-module`, `kmp-multi-target`, `kmp-no-jvm`, `kmp-multi-module`, `fake-publishing/{kmp-publisher,kmp-consumer}`, and `kmp-benchmark`.

**Not included:** `samples/compat/kotlin-*` (no per-sample `gradle.properties`; those cover the separate older-Kotlin-version axis and are a different question). The actual default flip (changing the plugin extension default) is also deferred — this probe only opts the samples in.

## Related Issue

Part of #79 (P8 default-flip readiness). Does not close it.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] No code change — sample configuration only
- [ ] Tests — _this PR **is** the test: the full `test-samples` + `test-cache-correctness` matrix with the flag on_
- [x] No breaking changes — _sample-local `gradle.properties` only; the plugin default is unchanged_

## Additional Context

What to watch on CI: the `test-samples` jobs (each sample built with the flag now on via `gradle.properties`), `test-cache-correctness` (already forced the flag), and `run-tests`. Clean-checkout CI won't exercise the flag-migration path (blocker 2 is a warm-dir-only scenario), so a green run here says the clean-build experimental path holds across JVM / Android / KMP / native / JS / Wasm / test-fixtures / multi-module / publishing. Any red job pinpoints a remaining pre-flip issue.

_Local sample builds weren't possible here (Gradle 9 dist download is egress-blocked); this relies entirely on CI._


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn98U6tgXhxX8Lb1YDPrG8)_