### PR TITLE
feat: generate fakes into Android (AGP) test fixtures

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -152,6 +152,9 @@ jobs:
           - sample: android-single-module
             path: samples/android-single-module
             tasks: build
+          - sample: android-test-fixtures
+            path: samples/android-test-fixtures
+            tasks: build
           - sample: jvm-test-fixtures
             path: samples/jvm-test-fixtures
             tasks: build

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -57,6 +57,10 @@ gradlePlugin {
             id = "fakt-sample-android"
             implementationClass = "FaktSampleAndroidPlugin"
         }
+        register("fakt-sample-android-fixtures") {
+            id = "fakt-sample-android-fixtures"
+            implementationClass = "FaktSampleAndroidFixturesPlugin"
+        }
         register("fakt-publishing") {
             id = "fakt-publishing"
             implementationClass = "FaktPublishingPlugin"

--- a/build-logic/src/main/kotlin/FaktSampleAndroidFixturesPlugin.kt
+++ b/build-logic/src/main/kotlin/FaktSampleAndroidFixturesPlugin.kt
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Convention plugin for a Fakt Android sample module that PRODUCES test fixtures.
+ *
+ * Applies [FaktSampleAndroidPlugin] (com.android.library + Kotlin Android + namespace/SDK config)
+ * and then turns on AGP's native test fixtures via `android { testFixtures { enable = true } }`.
+ * Fakt routes its generated fakes into that `testFixtures` source set (enabled by
+ * `fakt { useGradleTestFixtures.set(true) }` in the module build script).
+ *
+ * Kotlin compilation of the Android `testFixtures` source set additionally requires the Gradle
+ * property `android.experimental.enableTestFixturesKotlinSupport=true` on AGP 8.x (default on AGP
+ * 9.0+); the sample sets it in `gradle.properties`.
+ */
+class FaktSampleAndroidFixturesPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("fakt-sample-android")
+
+            extensions.configure<LibraryExtension> { testFixtures { enable = true } }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/FaktSampleAndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/FaktSampleAndroidPlugin.kt
@@ -18,6 +18,11 @@ import org.gradle.kotlin.dsl.configure
  * - Android configuration (compileSdk 35, minSdk 24)
  * - Java 11 source/target compatibility
  * - Common test dependencies (JUnit 5, parallel execution)
+ *
+ * The Android `namespace` is derived from the module name so multi-module Android samples get a
+ * unique R-class package per module (two modules sharing a namespace collide on `R`). The single
+ * `android-single-module` sample keeps its historical namespace, since camel-casing its name yields
+ * exactly `androidSingleModule`.
  */
 class FaktSampleAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -28,7 +33,7 @@ class FaktSampleAndroidPlugin : Plugin<Project> {
 
             // Configure Android Library extension
             extensions.configure<LibraryExtension> {
-                namespace = "com.rsicarelli.fakt.samples.androidSingleModule"
+                namespace = "com.rsicarelli.fakt.samples.${moduleNamespaceSuffix(target.name)}"
                 compileSdk = 35 // Latest stable
 
                 defaultConfig {
@@ -50,3 +55,9 @@ class FaktSampleAndroidPlugin : Plugin<Project> {
         }
     }
 }
+
+/** Converts a kebab-case module name to a camelCase namespace suffix (`a-b-c` -> `aBC`). */
+private fun moduleNamespaceSuffix(moduleName: String): String =
+    moduleName.split('-', '_').filter { it.isNotEmpty() }.mapIndexed { index, part ->
+        if (index == 0) part else part.replaceFirstChar { it.uppercaseChar() }
+    }.joinToString("")

--- a/compiler/src/test/kotlin/com/rsicarelli/fakt/compiler/fir/generation/FaktTestFixturesOutputDirTest.kt
+++ b/compiler/src/test/kotlin/com/rsicarelli/fakt/compiler/fir/generation/FaktTestFixturesOutputDirTest.kt
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.compiler.fir.generation
+
+import com.rsicarelli.fakt.compiler.api.EmitPhase
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Proves the compiler honors a `testFixtures` output directory end-to-end. The Gradle plugin routes
+ * fakes to `build/generated/fakt/testFixtures/kotlin` whenever `useGradleTestFixtures` resolves
+ * active (JVM `java-test-fixtures` OR Android `com.android.library`) — `SourceSetDiscovery` derives
+ * that path from the same flag. This test drives the REAL plugin with such a
+ * [com.rsicarelli.fakt.compiler.api.SourceSetContext] output directory and asserts the generated
+ * fakes physically land there, without needing Gradle or the Android SDK.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktTestFixturesOutputDirTest {
+
+    @Test
+    fun `GIVEN testFixtures output dir WHEN plugin generates THEN fakes are written under it`() {
+        // Given — the exact relative shape the Gradle plugin computes for test-fixtures mode.
+        val base = Files.createTempDirectory("fakt-fixtures").toFile()
+        val outputDir = File(base, "generated/fakt/testFixtures/kotlin")
+        try {
+            // When
+            val outcome =
+                FullPluginCompilationHarness.compile(
+                    fixtures =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Fixture.kt",
+                                """
+                                package fixtures
+                                import com.rsicarelli.fakt.Fake
+
+                                @Fake
+                                interface UserRepository {
+                                    fun findById(id: Long): String
+                                }
+                                """
+                                    .trimIndent(),
+                            )
+                        ),
+                    emitPhase = EmitPhase.IR,
+                    outputDir = outputDir,
+                )
+
+            // Then — the fake compiled and its file exists under the testFixtures directory.
+            assertEquals(KotlinCompilation.ExitCode.OK, outcome.exitCode, outcome.messages)
+            val generatedPath =
+                outcome.generatedFiles.keys.singleOrNull {
+                    it.endsWith("FakeUserRepositoryImpl.kt")
+                }
+            assertTrue(
+                generatedPath != null,
+                "expected FakeUserRepositoryImpl.kt in ${outcome.generatedFiles.keys}",
+            )
+            assertTrue(
+                File(outputDir, generatedPath).isFile,
+                "generated fake must physically exist under the testFixtures/kotlin output dir",
+            )
+            assertTrue(
+                outputDir.path.replace(File.separatorChar, '/').endsWith("testFixtures/kotlin"),
+                "precondition: the driven output dir is the testFixtures path",
+            )
+        } finally {
+            base.deleteRecursively()
+        }
+    }
+}

--- a/docs/user-guide/plugin-configuration.md
+++ b/docs/user-guide/plugin-configuration.md
@@ -29,8 +29,10 @@ fakt {
     // Control mutable fake generation (default: false)
     enableMutableFakes.set(false)  // Set to true for mutable fakes by default
 
-    // Generate fakes to testFixtures source set (default: false, JVM only)
-    useGradleTestFixtures.set(false)  // Requires `java-test-fixtures` plugin
+    // Generate fakes to testFixtures source set (default: false)
+    // JVM: requires `java-test-fixtures` plugin. Android: requires
+    // `android { testFixtures { enable = true } }` (see the Test Fixtures guide).
+    useGradleTestFixtures.set(false)
 
     // Multi-module: Collect fakes from another module (default: not set)
     @OptIn(com.rsicarelli.fakt.compiler.api.ExperimentalFaktMultiModule::class)

--- a/docs/user-guide/test-fixtures.md
+++ b/docs/user-guide/test-fixtures.md
@@ -1,9 +1,12 @@
-# Test Fixtures (JVM)
+# Test Fixtures (JVM & Android)
 
-Share generated fakes across JVM modules using Gradle's built-in [test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) plugin — no collector module needed.
+Share generated fakes across modules using Gradle test fixtures — no collector module needed. Two flavors are supported:
 
-!!! note "JVM Only"
-    This feature requires the `java-test-fixtures` Gradle plugin, which is only available for JVM and Android projects. For KMP multi-module projects, use the [Collector Module](multi-module.md) approach instead.
+- **JVM** — the Gradle [`java-test-fixtures`](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) plugin.
+- **Android** — AGP's native `android { testFixtures { enable = true } }` (the `java-test-fixtures` plugin cannot be applied to an Android module — it breaks Gradle sync).
+
+!!! note "Single-platform only"
+    Test fixtures apply to single-platform JVM and Android library modules. For KMP multi-module projects, use the [Collector Module](multi-module.md) approach instead. (A KMP `androidTarget()`'s fixtures are a different mechanism and are out of scope here — this covers `com.android.library` modules.)
 
 ---
 
@@ -11,7 +14,7 @@ Share generated fakes across JVM modules using Gradle's built-in [test fixtures]
 
 | | Test Fixtures | Collector Module |
 |---|---|---|
-| **Platform** | JVM / Android only | KMP + JVM + Android |
+| **Platform** | JVM + Android (single-platform) | KMP + JVM + Android |
 | **Extra module needed?** | No | Yes (`:module-fakes`) |
 | **Setup complexity** | Minimal (2 lines) | Moderate (new module + config) |
 | **Consumer dependency** | `testFixtures(projects.core)` | `implementation(projects.core.fakes)` |
@@ -101,37 +104,113 @@ class UserServiceTest {
 
 ---
 
+## Android (AGP) modules
+
+Android library modules can't apply `java-test-fixtures` (it breaks Gradle sync with
+`Neither the source set nor the artifact property was populated by the Android Gradle plugin`).
+Use AGP's own test fixtures instead — Fakt detects the Android plugin and routes generated fakes
+into the AGP `testFixtures` source set.
+
+### Producer (`com.android.library`)
+
+```kotlin
+// producer/build.gradle.kts
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.fakt)
+}
+
+android {
+    testFixtures {
+        enable = true
+    }
+}
+
+fakt {
+    useGradleTestFixtures.set(true) // works for both JVM and Android
+}
+```
+
+!!! warning "AGP 8.x needs an experimental flag"
+    Kotlin compilation of the Android `testFixtures` source set requires this in
+    `gradle.properties` on **AGP 8.x**:
+
+    ```properties
+    android.experimental.enableTestFixturesKotlinSupport=true
+    ```
+
+    Without it, AGP leaves `testFixtures` Java-only, no `compileDebugTestFixturesKotlin` task is
+    created, and the generated Kotlin fakes are silently dropped. On **AGP 9.0+** this is the
+    default and the property is unnecessary. The minimum supported floor is **AGP 8.11** — AGP ≤ 8.7
+    calls a Kotlin Gradle Plugin API (`KotlinJvmOptions.getUseK2()`) that Kotlin 2.3.20, Fakt's
+    compiler version, removed, so it cannot compile Android test-fixtures Kotlin.
+
+### Consumer (must be an Android module)
+
+```kotlin
+// consumer/build.gradle.kts
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+dependencies {
+    implementation(projects.producer)
+    testImplementation(testFixtures(projects.producer))
+}
+```
+
+!!! note "Consumer must be Android"
+    A plain JVM module cannot resolve an Android `testFixtures` variant. Consume Android test
+    fixtures from another Android module.
+
+---
+
 ## How It Works
 
-1. Fakt detects `java-test-fixtures` plugin and `useGradleTestFixtures.set(true)`
+1. Fakt detects `useGradleTestFixtures.set(true)` **and** a testFixtures source — either the
+   `java-test-fixtures` plugin (JVM) or `com.android.library` / `com.android.application` (Android)
 2. Generated fakes go to `build/generated/fakt/testFixtures/kotlin/` instead of `test/`
-3. The `testFixtures` source set is configured to include the generated directory
+3. The `testFixtures` source set is wired to include the generated directory: the JVM Java source
+   set for `java-test-fixtures`, and every per-variant `compile*TestFixturesKotlin` task for Android
 4. The module's own tests can use the fakes (Gradle makes testFixtures visible to test automatically)
-5. Other modules import fakes via `testFixtures(project(":core"))` — standard Gradle mechanism
+5. Other modules import fakes via `testFixtures(project(":producer"))` — standard Gradle mechanism
 
 ---
 
 ## Validation
 
-If `useGradleTestFixtures` is enabled but the `java-test-fixtures` plugin is not applied, Fakt emits a warning and falls back to the default `test` source set:
+If `useGradleTestFixtures` is enabled but no testFixtures source is available (neither the
+`java-test-fixtures` plugin nor an Android plugin), Fakt emits a warning and falls back to the
+default `test` source set:
 
 ```
-Fakt: useGradleTestFixtures is enabled but the 'java-test-fixtures' plugin
-is not applied. Add `java-test-fixtures` to your plugins block:
-  plugins {
-      `java-test-fixtures`
-  }
+Fakt: useGradleTestFixtures is enabled but no testFixtures source is available. Apply ONE of:
+  • JVM: add the `java-test-fixtures` plugin
+      plugins { `java-test-fixtures` }
+  • Android: enable AGP test fixtures
+      android { testFixtures { enable = true } }
 Falling back to default 'test' source set.
 ```
+
+On Android, if the experimental Kotlin-test-fixtures property is missing, Fakt additionally warns
+that the generated Kotlin fakes won't be compiled into the testFixtures artifact (see the AGP 8.x
+note above).
 
 ---
 
 ## Sample Project
 
-See [`samples/jvm-test-fixtures/`](https://github.com/rsicarelli/fakt/tree/main/samples/jvm-test-fixtures) for a working multi-module example with:
+See [`samples/jvm-test-fixtures/`](https://github.com/rsicarelli/fakt/tree/main/samples/jvm-test-fixtures) for a working JVM multi-module example with:
 
 - `core/` — Producer with interface, abstract class, and open class
 - `app/` — Consumer using fakes from core's testFixtures
+
+See [`samples/android-test-fixtures/`](https://github.com/rsicarelli/fakt/tree/main/samples/android-test-fixtures) for the Android (AGP) equivalent:
+
+- `producer/` — `com.android.library` with `testFixtures { enable = true }` and `@Fake` interfaces
+- `consumer/` — Android library consuming the fakes via `testImplementation(testFixtures(...))`
 
 ---
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -26,6 +26,50 @@ private fun isDrivablePlatform(platformTypeName: String): Boolean =
     }
 
 /**
+ * Pure decision for whether Fakt should route generated fakes into a `testFixtures` source set.
+ *
+ * Test-fixtures mode requires the opt-in flag AND a build that actually has a `testFixtures`
+ * compilation to receive them — supplied either by the `java-test-fixtures` Gradle plugin (JVM) or
+ * by the Android Gradle plugin's `android { testFixtures { enable = true } }`
+ * (`com.android.library` / `com.android.application`). Extracted as a `Project`-free function so
+ * the full truth table is unit-testable without a Gradle project (mirrors
+ * [shouldWireGeneratedDir]).
+ *
+ * @param useGradleTestFixtures the resolved `fakt { useGradleTestFixtures }` value.
+ * @param hasJavaTestFixtures whether the `java-test-fixtures` plugin is applied.
+ * @param hasAndroidLibrary whether an Android library/application plugin is applied.
+ */
+internal fun shouldEnableTestFixtures(
+    useGradleTestFixtures: Boolean,
+    hasJavaTestFixtures: Boolean,
+    hasAndroidLibrary: Boolean,
+): Boolean = useGradleTestFixtures && (hasJavaTestFixtures || hasAndroidLibrary)
+
+/**
+ * Warns when an Android module routes fakes into `testFixtures` without the experimental Gradle
+ * property that turns on Kotlin compilation for the Android `testFixtures` source set. Without it
+ * AGP 8.x leaves that source set Java-only, no `*TestFixturesKotlin` task materializes, and the
+ * generated Kotlin fakes are silently dropped. The property is unnecessary on AGP 9.0 (Kotlin test
+ * fixtures are on by default), so this stays a warning, not an error. Read lazily via
+ * [org.gradle.api.provider.ProviderFactory.gradleProperty] to remain configuration-cache safe.
+ *
+ * Top-level (not a member) so [FaktGradleSubplugin] stays under detekt's function-count threshold.
+ */
+private fun warnIfMissingAndroidTestFixturesKotlinFlag(project: Project) {
+    val property = FaktGradleSubplugin.ANDROID_TEST_FIXTURES_KOTLIN_PROPERTY
+    val flag = project.providers.gradleProperty(property).orNull
+    if (flag?.toBooleanStrictOrNull() != true) {
+        project.logger.warn(
+            "Fakt: Android test fixtures need Kotlin compilation for the testFixtures source set. " +
+                "Add to gradle.properties:\n" +
+                "  $property=true\n" +
+                "(required on AGP 8.x; unnecessary on AGP 9.0+, where it is the default). Without " +
+                "it the generated Kotlin fakes are not compiled into the testFixtures artifact."
+        )
+    }
+}
+
+/**
  * Gradle plugin for Fakt compiler plugin integration.
  *
  * This is the main entry point that bridges Gradle build system with the Fakt compiler plugin. It
@@ -102,6 +146,13 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         internal const val WORKER_CONFIGURATION: String = "faktWorker"
         internal const val COMPILER_CLASSPATH_CONFIGURATION: String = "faktCompiler"
         internal const val GRADLE_PROPERTY_FLAG: String = "fakt.useExperimentalGenerateTask"
+
+        /**
+         * AGP experimental Gradle property that enables Kotlin compilation for the Android
+         * `testFixtures` source set. Required on AGP 8.x; the default on AGP 9.0+.
+         */
+        internal const val ANDROID_TEST_FIXTURES_KOTLIN_PROPERTY: String =
+            "android.experimental.enableTestFixturesKotlinSupport"
 
         /** KGP metadata compilation whose default source set is `commonMain`. */
         private const val COMMON_MAIN_COMPILATION: String = "commonMain"
@@ -212,35 +263,57 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     /**
      * Resolves whether test fixtures mode should be active.
      *
-     * Returns `true` only when both conditions are met:
-     * 1. `useGradleTestFixtures` is set to `true` in the extension
-     * 2. The `java-test-fixtures` Gradle plugin is applied to the project
+     * Returns `true` only when `useGradleTestFixtures` is set AND the project has a source of a
+     * `testFixtures` compilation:
+     * - the `java-test-fixtures` Gradle plugin (JVM modules), or
+     * - the Android Gradle plugin (`com.android.library` / `com.android.application`), where the
+     *   `testFixtures` source set comes from `android { testFixtures { enable = true } }`.
      *
-     * If the option is enabled but the plugin is missing, emits a warning and returns `false`.
+     * If the option is enabled but neither is present, emits a warning and returns `false`. When
+     * the Android path is taken, additionally warns if the Kotlin-test-fixtures experimental Gradle
+     * property is missing (required on AGP 8.x; unnecessary on AGP 9.0).
      */
     internal fun resolveTestFixturesMode(
         project: Project,
         extension: FaktPluginExtension,
     ): Boolean {
-        if (!extension.useGradleTestFixtures.get()) return false
+        val useGradleTestFixtures = extension.useGradleTestFixtures.get()
+        val hasJavaTestFixtures = project.plugins.hasPlugin("java-test-fixtures")
+        val hasAndroidLibrary =
+            project.plugins.hasPlugin("com.android.library") ||
+                project.plugins.hasPlugin("com.android.application")
 
-        val hasTestFixturesPlugin = project.plugins.hasPlugin("java-test-fixtures")
-        if (!hasTestFixturesPlugin) {
-            project.logger.warn(
-                "Fakt: useGradleTestFixtures is enabled but the 'java-test-fixtures' plugin " +
-                    "is not applied. Add `java-test-fixtures` to your plugins block:\n" +
-                    "  plugins {\n" +
-                    "      `java-test-fixtures`\n" +
-                    "  }\n" +
-                    "Falling back to default 'test' source set."
+        val enabled =
+            shouldEnableTestFixtures(
+                useGradleTestFixtures = useGradleTestFixtures,
+                hasJavaTestFixtures = hasJavaTestFixtures,
+                hasAndroidLibrary = hasAndroidLibrary,
             )
-        } else {
-            project.logger.info(
-                "Fakt: Test fixtures mode enabled - generating fakes to testFixtures source set"
-            )
+
+        if (!enabled) {
+            // Warn only when the user opted in but no testFixtures source exists; the common
+            // default (`useGradleTestFixtures = false`) stays silent.
+            if (useGradleTestFixtures) {
+                project.logger.warn(
+                    "Fakt: useGradleTestFixtures is enabled but no testFixtures source is " +
+                        "available. Apply ONE of:\n" +
+                        "  • JVM: add the `java-test-fixtures` plugin\n" +
+                        "      plugins { `java-test-fixtures` }\n" +
+                        "  • Android: enable AGP test fixtures\n" +
+                        "      android { testFixtures { enable = true } }\n" +
+                        "Falling back to default 'test' source set."
+                )
+            }
+            return false
         }
 
-        return hasTestFixturesPlugin
+        project.logger.info(
+            "Fakt: Test fixtures mode enabled - generating fakes to testFixtures source set"
+        )
+        if (hasAndroidLibrary) {
+            warnIfMissingAndroidTestFixturesKotlinFlag(project)
+        }
+        return true
     }
 
     /**
@@ -295,6 +368,19 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         if (extension.collectFrom.isPresent) {
             project.logger.info(
                 "Fakt: Skipping compiler plugin for '${kotlinCompilation.name}' (collector mode)"
+            )
+            return false
+        }
+
+        // A module's testFixtures compilation (AGP: "debugTestFixtures"/"releaseTestFixtures",
+        // JVM: "testFixtures") is NOT flagged `isTestCompilation`, yet it holds no @Fake sources to
+        // analyze — it CONSUMES the generated fakes we route into it. Applying the plugin there
+        // would run generation over the fixtures sources and derive a self-referential output dir
+        // from that compilation's own default source set. Exclude it explicitly.
+        if (kotlinCompilation.name.contains("testFixtures", ignoreCase = true)) {
+            project.logger.info(
+                "Fakt: Skipping compiler plugin for '${kotlinCompilation.name}' " +
+                    "(testFixtures compilation consumes generated fakes, it does not produce them)"
             )
             return false
         }

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfigurator.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfigurator.kt
@@ -145,25 +145,47 @@ internal class SourceSetConfigurator(
     }
 
     /**
-     * Configure testFixtures source set to include generated fakes.
+     * Configure the `testFixtures` source set to include generated fakes.
      *
      * When `useGradleTestFixtures` is enabled, generated fakes go to
-     * `build/generated/fakt/testFixtures/kotlin/` and are added to the `testFixtures` Java source
-     * set. This makes fakes available to:
+     * `build/generated/fakt/testFixtures/kotlin/`. This makes them available to:
      * - The module's own tests (automatically via Gradle)
      * - Other modules via `testFixtures(project(":this-module"))` dependency
+     *
+     * Two wiring routes, applied together so both JVM and Android modules are covered:
+     * 1. **JVM (`java-test-fixtures`):** add the dir to the `testFixtures` Java source set. KGP
+     *    compiles the Kotlin files it finds there and the Java plugin publishes them into the
+     *    testFixtures artifact. No-ops on Android (no `JavaPluginExtension`).
+     * 2. **Android (and JVM):** source the dir into every `compile*TestFixturesKotlin` task.
+     *    Android has no `JavaPluginExtension`, so this Kotlin-compile-task route is the only one
+     *    that reaches AGP's per-variant `compileDebugTestFixturesKotlin` /
+     *    `compileReleaseTestFixturesKotlin`. Selection reuses [shouldWireGeneratedDir] (producing
+     *    token `"main"` matches every variant), keeping the scoping identical to the experimental
+     *    generate-task path. `configureEach` is lazy so AGP's later-registered per-variant tasks
+     *    are still covered.
      */
     private fun configureTestFixturesSourceSet() {
         val generatedDir =
             File(project.layout.buildDirectory.get().asFile, "generated/fakt/testFixtures/kotlin")
 
-        // Add generated directory to the testFixtures Java source set
+        // Route 1 — JVM java-test-fixtures Java source set (no-op on Android).
         project.extensions
             .findByType(org.gradle.api.plugins.JavaPluginExtension::class.java)
             ?.sourceSets
             ?.findByName("testFixtures")
             ?.java
             ?.srcDir(generatedDir)
+
+        // Route 2 — Kotlin testFixtures compile tasks (Android variants + JVM).
+        project.tasks.withType(AbstractKotlinCompile::class.java).configureEach { task ->
+            if (shouldWireGeneratedDir(task.name, "main", useTestFixtures = true)) {
+                task.source(generatedDir)
+                project.logger.info(
+                    "Fakt: Configured testFixtures compile task '${task.name}' " +
+                        "to include generated sources at $generatedDir"
+                )
+            }
+        }
 
         project.logger.info(
             "Fakt: Configured testFixtures source set to include generated sources at $generatedDir"

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
@@ -234,6 +234,27 @@ class FaktGradleSubpluginFlagResolutionTest {
         )
     }
 
+    @Test
+    fun `GIVEN testFixtures compilation WHEN isApplicable THEN returns false`(
+        @TempDir tempDir: File
+    ) {
+        val project = createJvmProject(tempDir)
+        project.pluginManager.apply("java-test-fixtures")
+        project.evaluate()
+        val subplugin = project.faktSubplugin()
+
+        // The testFixtures compilation is NOT flagged `isTestCompilation`, so without the explicit
+        // name exclusion `isApplicable` would return true and the plugin would run generation over
+        // the fixtures sources (self-referential wiring). AGP's
+        // debugTestFixtures/releaseTestFixtures
+        // behave the same; the JVM `testFixtures` compilation is the SDK-free proxy for that case.
+        assertFalse(
+            subplugin.isApplicable(project.jvmCompilation("testFixtures")),
+            "The testFixtures compilation consumes generated fakes — it must be excluded from " +
+                "generation even though it is not a test compilation.",
+        )
+    }
+
     // -- TestKit: gradleProperty branches ---------------------------------------------------------
 
     @Test

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktTestFixturesModeTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktTestFixturesModeTest.kt
@@ -1,0 +1,94 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Pins the full truth table of [shouldEnableTestFixtures], the pure predicate behind
+ * [FaktGradleSubplugin.resolveTestFixturesMode]. Test-fixtures mode requires the opt-in flag AND a
+ * build that actually owns a `testFixtures` compilation — supplied by the `java-test-fixtures`
+ * plugin (JVM) or by the Android Gradle plugin (`com.android.library` / `com.android.application`).
+ * Extracting it as a `Project`-free function is what makes this table unit-testable without a
+ * Gradle project.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktTestFixturesModeTest {
+
+    @Test
+    fun `GIVEN flag off WHEN neither fixtures source present THEN disabled`() {
+        assertFalse(
+            shouldEnableTestFixtures(
+                useGradleTestFixtures = false,
+                hasJavaTestFixtures = false,
+                hasAndroidLibrary = false,
+            ),
+            "Without the opt-in flag fakes go to the default test source set.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag off WHEN java-test-fixtures present THEN disabled`() {
+        assertFalse(
+            shouldEnableTestFixtures(
+                useGradleTestFixtures = false,
+                hasJavaTestFixtures = true,
+                hasAndroidLibrary = false,
+            ),
+            "The opt-in flag gates everything — an applied plugin alone must not enable it.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag on WHEN no fixtures source present THEN disabled`() {
+        assertFalse(
+            shouldEnableTestFixtures(
+                useGradleTestFixtures = true,
+                hasJavaTestFixtures = false,
+                hasAndroidLibrary = false,
+            ),
+            "The flag alone is insufficient — there must be a testFixtures compilation to receive " +
+                "the fakes, so the caller falls back to the default test source set.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag on WHEN java-test-fixtures present THEN enabled`() {
+        assertTrue(
+            shouldEnableTestFixtures(
+                useGradleTestFixtures = true,
+                hasJavaTestFixtures = true,
+                hasAndroidLibrary = false,
+            ),
+            "The classic JVM path: flag + `java-test-fixtures` plugin.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag on WHEN android library present THEN enabled`() {
+        assertTrue(
+            shouldEnableTestFixtures(
+                useGradleTestFixtures = true,
+                hasJavaTestFixtures = false,
+                hasAndroidLibrary = true,
+            ),
+            "The Android path: flag + AGP, where testFixtures comes from " +
+                "`android { testFixtures { enable = true } }`.",
+        )
+    }
+
+    @Test
+    fun `GIVEN flag on WHEN both sources present THEN enabled`() {
+        assertTrue(
+            shouldEnableTestFixtures(
+                useGradleTestFixtures = true,
+                hasJavaTestFixtures = true,
+                hasAndroidLibrary = true,
+            ),
+            "Either source is sufficient; having both still enables the mode.",
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktWireTestSrcDirTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktWireTestSrcDirTest.kt
@@ -117,4 +117,39 @@ class FaktWireTestSrcDirTest {
                 "into both `test` and `testFixtures` outputs (gap 3).",
         )
     }
+
+    @Test
+    fun `GIVEN android main producer with fixtures on WHEN matching the debug test-fixtures compile THEN it is wired`() {
+        assertTrue(
+            shouldWireGeneratedDir(
+                "compileDebugTestFixturesKotlin",
+                "main",
+                useTestFixtures = true,
+            ),
+            "The legacy path drives Android fixtures with a `main` producing token, so every " +
+                "AGP variant's testFixtures compile (compileDebugTestFixturesKotlin) sources fakes.",
+        )
+    }
+
+    @Test
+    fun `GIVEN android main producer with fixtures on WHEN matching the release test-fixtures compile THEN it is wired`() {
+        assertTrue(
+            shouldWireGeneratedDir(
+                "compileReleaseTestFixturesKotlin",
+                "main",
+                useTestFixtures = true,
+            ),
+            "Both AGP variants publish testFixtures; the release variant's compile must source " +
+                "the same generated fakes.",
+        )
+    }
+
+    @Test
+    fun `GIVEN android main producer with fixtures on WHEN matching the debug unit-test compile THEN it is not wired`() {
+        assertFalse(
+            shouldWireGeneratedDir("compileDebugUnitTestKotlin", "main", useTestFixtures = true),
+            "With fixtures enabled the Android unit-test compile consumes fakes via the " +
+                "testFixtures dependency — it must not source the generated dir directly.",
+        )
+    }
 }

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfiguratorJvmTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/SourceSetConfiguratorJvmTest.kt
@@ -103,6 +103,29 @@ class SourceSetConfiguratorJvmTest {
     }
 
     @Test
+    fun `GIVEN useTestFixtures true AND java-test-fixtures applied WHEN configureSourceSets THEN compileTestFixturesKotlin sources include generated dir`(
+        @TempDir tempDir: File
+    ) {
+        val project = createKotlinJvmProject(tempDir)
+        project.pluginManager.apply("java-test-fixtures")
+        val marker = plantMarker(project, "generated/fakt/testFixtures/kotlin")
+
+        SourceSetConfigurator(project, useTestFixtures = true).configureSourceSets()
+
+        // The Kotlin-compile-task route (Route 2) is the ONLY one that reaches AGP's
+        // compile*TestFixturesKotlin tasks, which have no JavaPluginExtension backing. Proving it
+        // on
+        // the JVM `compileTestFixturesKotlin` task exercises the same mechanism without the Android
+        // SDK (ProjectBuilder cannot apply com.android.library).
+        val fixturesTask = kotlinCompileTask(project, "compileTestFixturesKotlin")
+        assertTrue(
+            fixturesTask.sources.files.contains(marker),
+            "compileTestFixturesKotlin must source build/generated/fakt/testFixtures/kotlin; " +
+                "sources: ${fixturesTask.sources.files}",
+        )
+    }
+
+    @Test
     fun `GIVEN useTestFixtures true AND java-test-fixtures NOT applied WHEN configureSourceSets THEN completes without error`(
         @TempDir tempDir: File
     ) {

--- a/samples/android-test-fixtures/README.md
+++ b/samples/android-test-fixtures/README.md
@@ -1,0 +1,41 @@
+<!--
+  Copyright (C) 2025 Rodrigo Sicarelli
+  SPDX-License-Identifier: Apache-2.0
+-->
+# Android test fixtures sample
+
+Demonstrates Fakt generating fakes into an **Android library's native `testFixtures`** source set
+(AGP `android { testFixtures { enable = true } }`) and another Android module consuming them —
+the AGP analogue of the JVM `java-test-fixtures` flow.
+
+Covers discussions
+[#87](https://github.com/rsicarelli/fakt/discussions/87) and
+[#109](https://github.com/rsicarelli/fakt/discussions/109).
+
+## Layout
+
+| Module | Role | Key config |
+|--------|------|------------|
+| `:producer` | Android library that declares `@Fake` interfaces | `id("fakt-sample-android-fixtures")` (enables `testFixtures`), `fakt { useGradleTestFixtures.set(true) }` |
+| `:consumer` | Android library that USES the fakes | `testImplementation(testFixtures(projects.producer))`, **no** Fakt plugin |
+
+Fakt runs on `:producer`'s `main` compilation and writes the generated fakes to
+`producer/build/generated/fakt/testFixtures/kotlin/`. AGP compiles them per variant
+(`compileDebugTestFixturesKotlin` / `compileReleaseTestFixturesKotlin`) and publishes them in the
+producer's `testFixtures` artifact. `:consumer`'s unit tests then instantiate
+`fakeUserRepository { }` without applying the Fakt plugin themselves.
+
+## Requirements
+
+- **AGP 8.x** needs `android.experimental.enableTestFixturesKotlinSupport=true` in
+  `gradle.properties` so the `testFixtures` source set compiles Kotlin (already set here). On
+  **AGP 9.0+** this is the default and the property is unnecessary.
+- The consumer must be an **Android** module: a plain JVM module cannot resolve an Android
+  `testFixtures` variant.
+
+## Run
+
+```bash
+make publish-local
+./gradlew -p samples/android-test-fixtures build
+```

--- a/samples/android-test-fixtures/build.gradle.kts
+++ b/samples/android-test-fixtures/build.gradle.kts
@@ -1,0 +1,2 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0

--- a/samples/android-test-fixtures/consumer/build.gradle.kts
+++ b/samples/android-test-fixtures/consumer/build.gradle.kts
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+
+plugins {
+    // No Fakt plugin here — the consumer only USES the fakes published in the producer's
+    // testFixtures artifact. This is the AGP analogue of discussion #109: an Android module
+    // consuming another Android module's test fixtures.
+    id("fakt-sample-android")
+}
+
+dependencies {
+    implementation(projects.producer)
+
+    testImplementation(testFixtures(projects.producer))
+    testImplementation(kotlin("test"))
+}

--- a/samples/android-test-fixtures/consumer/src/main/AndroidManifest.xml
+++ b/samples/android-test-fixtures/consumer/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2025 Rodrigo Sicarelli
+  SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Empty manifest - required for Android library modules -->
+</manifest>

--- a/samples/android-test-fixtures/consumer/src/main/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/consumer/UserService.kt
+++ b/samples/android-test-fixtures/consumer/src/main/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/consumer/UserService.kt
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.samples.androidtestfixtures.consumer
+
+import com.rsicarelli.fakt.samples.androidtestfixtures.producer.UserRepository
+import com.rsicarelli.fakt.samples.androidtestfixtures.producer.models.User
+
+/** Production code in the consumer module that depends on the producer's [UserRepository]. */
+class UserService(private val repository: UserRepository) {
+
+    fun displayName(id: String): String = repository.findById(id)?.name ?: "Unknown"
+
+    fun registeredCount(): Int = repository.users.size
+}

--- a/samples/android-test-fixtures/consumer/src/test/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/consumer/UserServiceTest.kt
+++ b/samples/android-test-fixtures/consumer/src/test/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/consumer/UserServiceTest.kt
@@ -1,0 +1,70 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.samples.androidtestfixtures.consumer
+
+import com.rsicarelli.fakt.samples.androidtestfixtures.producer.fakeUserRepository
+import com.rsicarelli.fakt.samples.androidtestfixtures.producer.models.User
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Consumes the `fakeUserRepository { }` fake generated into the producer's Android `testFixtures`
+ * source set and pulled in via `testImplementation(testFixtures(project(":producer")))`.
+ *
+ * This is the end-to-end proof for discussion #109: an Android (AGP) module using another Android
+ * module's Fakt-generated test fixtures, which the old `java-test-fixtures`-only path could not
+ * support.
+ */
+class UserServiceTest {
+
+    @Test
+    fun `GIVEN fake user repository from producer test fixtures WHEN displaying a name THEN service resolves it`() {
+        // Given — the fake type comes from the producer's testFixtures artifact.
+        val repository =
+            fakeUserRepository {
+                findById { id ->
+                    if (id == "1") User("1", "Alice", "alice@example.com") else null
+                }
+            }
+        val service = UserService(repository)
+
+        // When
+        val name = service.displayName("1")
+        val missing = service.displayName("missing")
+
+        // Then
+        assertEquals("Alice", name)
+        assertEquals("Unknown", missing)
+    }
+
+    @Test
+    fun `GIVEN fake user repository with configured users WHEN counting THEN service reports the size`() {
+        // Given
+        val repository =
+            fakeUserRepository {
+                users {
+                    listOf(
+                        User("1", "Alice", "alice@example.com"),
+                        User("2", "Bob", "bob@example.com"),
+                    )
+                }
+            }
+        val service = UserService(repository)
+
+        // When
+        val count = service.registeredCount()
+
+        // Then
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun `GIVEN fake user repository with defaults WHEN used THEN smart defaults apply`() {
+        // Given — no behavior configured; Fakt supplies smart defaults.
+        val service = UserService(fakeUserRepository())
+
+        // When / Then
+        assertEquals(0, service.registeredCount())
+        assertEquals("Unknown", service.displayName("any"))
+    }
+}

--- a/samples/android-test-fixtures/gradle.properties
+++ b/samples/android-test-fixtures/gradle.properties
@@ -1,0 +1,21 @@
+# Copyright (C) 2025 Rodrigo Sicarelli
+# SPDX-License-Identifier: Apache-2.0
+
+# Gradle
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.parallel=true
+
+# Kotlin
+kotlin.code.style=official
+kotlin.incremental=true
+
+# Android
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+
+# Enable Kotlin compilation of the Android testFixtures source set.
+# Required on AGP 8.x so that `compileDebugTestFixturesKotlin` materializes and Fakt's generated
+# Kotlin fakes are compiled into the testFixtures artifact. Unnecessary (the default) on AGP 9.0+.
+android.experimental.enableTestFixturesKotlinSupport=true

--- a/samples/android-test-fixtures/producer/build.gradle.kts
+++ b/samples/android-test-fixtures/producer/build.gradle.kts
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+
+import com.rsicarelli.fakt.compiler.api.LogLevel
+
+plugins {
+    id("fakt-sample-android-fixtures")
+    alias(libs.plugins.fakt)
+}
+
+dependencies {
+    implementation(libs.fakt.annotations)
+
+    // Generated fakes track call history with kotlinx-coroutines StateFlow, so the testFixtures
+    // compilation (compile*TestFixturesKotlin) needs coroutines on its classpath.
+    testFixturesImplementation(libs.coroutines)
+}
+
+fakt {
+    logLevel.set(LogLevel.DEBUG)
+    // Routes generated fakes into the Android testFixtures source set (AGP native test fixtures,
+    // enabled by `android { testFixtures { enable = true } }` in the convention plugin) instead of
+    // the default `test` source set. The fakes are then published in the testFixtures artifact and
+    // consumed cross-module via `testImplementation(testFixtures(project(":producer")))`.
+    useGradleTestFixtures.set(true)
+}

--- a/samples/android-test-fixtures/producer/src/main/AndroidManifest.xml
+++ b/samples/android-test-fixtures/producer/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2025 Rodrigo Sicarelli
+  SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Empty manifest - required for Android library modules -->
+</manifest>

--- a/samples/android-test-fixtures/producer/src/main/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/producer/UserRepository.kt
+++ b/samples/android-test-fixtures/producer/src/main/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/producer/UserRepository.kt
@@ -1,0 +1,24 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.samples.androidtestfixtures.producer
+
+import com.rsicarelli.fakt.Fake
+import com.rsicarelli.fakt.samples.androidtestfixtures.producer.models.User
+
+/**
+ * A `@Fake` interface declared in an Android library's `main` source set.
+ *
+ * Fakt generates `fakeUserRepository { }` / `FakeUserRepositoryImpl` / `FakeUserRepositoryConfig`
+ * into this module's Android `testFixtures` source set (not `test`), so that OTHER Android modules
+ * can consume the fake via `testImplementation(testFixtures(project(":producer")))`.
+ */
+@Fake
+interface UserRepository {
+    val users: List<User>
+
+    fun findById(id: String): User?
+
+    fun save(user: User): User
+
+    fun delete(id: String): Boolean
+}

--- a/samples/android-test-fixtures/producer/src/main/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/producer/models/User.kt
+++ b/samples/android-test-fixtures/producer/src/main/kotlin/com/rsicarelli/fakt/samples/androidtestfixtures/producer/models/User.kt
@@ -1,0 +1,10 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.samples.androidtestfixtures.producer.models
+
+/** Simple domain model shared across the producer and its consumers. */
+data class User(
+    val id: String,
+    val name: String,
+    val email: String,
+)

--- a/samples/android-test-fixtures/settings.gradle.kts
+++ b/samples/android-test-fixtures/settings.gradle.kts
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+
+rootProject.name = "android-test-fixtures"
+
+pluginManagement {
+    includeBuild("../../build-logic")
+    repositories {
+        mavenLocal()
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
+dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+include(":producer", ":consumer")


### PR DESCRIPTION
## Description
Fakt's test-fixtures support previously only detected the JVM `java-test-fixtures` plugin, which cannot be applied to Android modules (it breaks Gradle sync with `Neither the source set nor the artifact property was populated by the Android Gradle plugin`). This routes generated fakes into AGP's native `testFixtures` source set, keeping **AGP 8.x backwards compatibility** (the capability exists on AGP 8.x; AGP 9.0 only adds ergonomics).

> **Split note:** this is the focused first PR (feature + core Android sample). The AGP-version compatibility matrix (`samples/compat-agp`, AGP 8.11 / 8.12 / 9.0) lands in a follow-up PR to keep this one reviewable.

**Plugin (`gradle-plugin`)**
- `resolveTestFixturesMode` now enables fixtures mode for `com.android.library` / `com.android.application`, via a new pure `shouldEnableTestFixtures()` helper; the fallback warning describes both the JVM and Android paths.
- `configureTestFixturesSourceSet` wires generated sources into every `compile*TestFixturesKotlin` task (reusing `shouldWireGeneratedDir`) — the only route that reaches AGP's per-variant tasks. The JVM `JavaPluginExtension` branch is unchanged. **Zero AGP types are referenced in the plugin**, so AGP DSL differences across 8.x→9.0 can't break it.
- `isApplicable` now excludes `testFixtures` compilations (they are not `isTestCompilation` but must not have generation run over them).
- Warns when an Android module is missing `android.experimental.enableTestFixturesKotlinSupport` (required on AGP 8.x, default on 9.0+); the plugin never sets it itself.

**Coverage**
- Pure truth-table test for `shouldEnableTestFixtures`.
- Android `testFixtures`-variant cases for `shouldWireGeneratedDir`.
- `compileTestFixturesKotlin` sourcing assertion (SDK-free proxy for the Android compile task) and an `isApplicable`-excludes-`testFixtures` test.
- Compiler-harness test proving generation lands in the `testFixtures` output dir.

**Sample + CI**
- `samples/android-test-fixtures/` — Android producer (`testFixtures { enable = true }`) + Android consumer whose tests instantiate the generated fakes (the #109 proof); wired into the `test-samples` matrix.

**Docs** — Test Fixtures guide and plugin-configuration updated for the Android path, the experimental flag, and the Android-consumer requirement.

## Related Issue
Related discussions: #87 (Support Android test fixtures) and #109 (generating fakes into AGP test fixtures packages). #87 was converted from issue #58.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [ ] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context
Verified locally against Gradle 8.14.3 (the pinned Gradle 9.0.0 distribution is unreachable from this environment): `:gradle-plugin:compileKotlin`, `:build-logic:compileKotlin`, the full `:gradle-plugin:test` suite, the compiler-harness test, and `spotlessCheck` / `detekt` all pass. The Android sample build runs in CI (no local Android SDK). This is a strict subset of a larger, fully-green branch — the same plugin/test code already passed the complete CI matrix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xXAnHJNi5h5yNLjeWGHQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017xXAnHJNi5h5yNLjeWGHQZ)_