### PR TITLE
fix(ci): bump mkdocs-material to 9.7.7 for pymdown-extensions 11 compat

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -9,7 +9,7 @@ mike==2.1.3
 mkdocs==1.6.1
 mkdocs-get-deps==0.2.0
 mkdocs-macros-plugin==1.3.9
-mkdocs-material==9.6.16
+mkdocs-material==9.7.7
 mkdocs-material-extensions==1.3.1
 mkdocs-callouts==1.16.0
 Pygments==2.20.0


### PR DESCRIPTION
## Description
The **Continuous Deploy** workflow ([run #144](https://github.com/rsicarelli/fakt/actions/runs/30919517286)) failed on `main` in the *Deploy snapshot documentation* job while installing `.github/workflows/mkdocs-requirements.txt`:

```
ERROR: Cannot install -r .github/workflows/mkdocs-requirements.txt (line 12) and pymdown-extensions==11.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested pymdown-extensions==11.0
    mkdocs-material 9.6.16 depends on pymdown-extensions~=10.2
ERROR: ResolutionImpossible
```

Dependabot bumped `pymdown-extensions` from `10.21.3` to `11.0` (#123), but the pinned `mkdocs-material==9.6.16` caps it at `~=10.2` (`>=10.2,<11`), so the pin was unsatisfiable and every docs deploy broke.

Rather than roll `pymdown-extensions` back, this **keeps the `11.0` bump** and upgrades the constraining package: `mkdocs-material` `9.7.0+` relaxed its requirement to `pymdown-extensions>=10.2` (upper bound dropped), so this bumps the theme `9.6.16` → `9.7.7` (latest patch of the 9.7 line).

| mkdocs-material | pymdown-extensions constraint | allows 11.0 |
|---|---|---|
| `9.6.16` (old) | `~=10.2` (`>=10.2,<11`) | ❌ |
| `9.7.0`+ | `>=10.2` | ✅ |
| `9.7.7` (this PR) | `>=10.2` | ✅ |

Verified locally with `pip install --dry-run` — resolution now succeeds, installing `pymdown-extensions-11.0` alongside `mkdocs-material-9.7.7`.

## Related Issue
N/A — regression from #123.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [ ] Code formatted: `./gradlew spotlessApply`
- [ ] Linter passing: `./gradlew lintKotlin`
- [ ] Static analysis: `./gradlew detekt`
- [ ] Tests added/updated and passing: `./gradlew test`
- [ ] Generated code compiles (verified with sample project)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

_CI-only change (Python docs requirements); Gradle/Kotlin checks are not applicable. Resolution verified via `pip install --dry-run`._

## Additional Context
`mkdocs-material` `9.6.16 → 9.7.7` is a minor/patch theme upgrade within the 9.x line; no config migration is required. The docs build in this same job exercises the theme, so a successful deploy confirms rendering. If a more conservative change is preferred, pinning `mkdocs-material==9.7.0` (the minimum that allows `pymdown-extensions` 11) is an alternative.