### PR TITLE
fix(codegen): import emptyFlow for Flow-returning fakes (#128)

### DIFF
--- a/codegen-runtime/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/FakeGenerator.kt
+++ b/codegen-runtime/src/main/kotlin/com/rsicarelli/fakt/codegen/extensions/FakeGenerator.kt
@@ -255,6 +255,20 @@ private fun generateCompleteFakeInternal(config: FakeGenerationConfig): CodeFile
             import("kotlinx.coroutines.flow.MutableStateFlow")
         }
 
+        // Flow<T> members default to emptyFlow(), a top-level function that needs an explicit
+        // import. Resolve each member type the same way the generator does, so nested cases (e.g.
+        // Result<Flow<T>>) are covered and StateFlow/SharedFlow (which don't emit emptyFlow) are
+        // not falsely matched.
+        val usesEmptyFlow = { type: String ->
+            resolver.resolve(parseType(type)).render().contains("emptyFlow(")
+        }
+        if (
+            methods.any { usesEmptyFlow(it.returnType) } ||
+                properties.any { usesEmptyFlow(it.type) }
+        ) {
+            import("kotlinx.coroutines.flow.emptyFlow")
+        }
+
         // Add call tracking imports (only needed when call history is enabled)
         if (generateCallHistory) {
             import("kotlinx.coroutines.flow.StateFlow")

--- a/codegen-runtime/src/test/kotlin/com/rsicarelli/fakt/codegen/extensions/FakeGeneratorTest.kt
+++ b/codegen-runtime/src/test/kotlin/com/rsicarelli/fakt/codegen/extensions/FakeGeneratorTest.kt
@@ -160,6 +160,73 @@ class FakeGeneratorTest {
     }
 
     @Test
+    fun `GIVEN generateCompleteFake WHEN method returns Flow THEN imports emptyFlow`() {
+        // GIVEN
+        val methods =
+            listOf(
+                MethodSpec(name = "observeUsers", params = emptyList(), returnType = "Flow<User>")
+            )
+
+        // WHEN
+        val file =
+            generateCompleteFake(
+                packageName = "com.example",
+                interfaceName = "UserService",
+                methods = methods,
+            )
+        val builder = CodeBuilder()
+        file.renderTo(builder)
+        val result = builder.build()
+
+        // THEN
+        assertContains(result, "import kotlinx.coroutines.flow.emptyFlow")
+    }
+
+    @Test
+    fun `GIVEN generateCompleteFake WHEN Flow property THEN imports emptyFlow`() {
+        // GIVEN
+        val properties = listOf(PropertySpec(name = "users", type = "Flow<User>"))
+
+        // WHEN
+        val file =
+            generateCompleteFake(
+                packageName = "com.example",
+                interfaceName = "UserStore",
+                properties = properties,
+            )
+        val builder = CodeBuilder()
+        file.renderTo(builder)
+        val result = builder.build()
+
+        // THEN
+        assertContains(result, "import kotlinx.coroutines.flow.emptyFlow")
+    }
+
+    @Test
+    fun `GIVEN generateCompleteFake WHEN no Flow member THEN omits emptyFlow import`() {
+        // GIVEN
+        val methods =
+            listOf(MethodSpec(name = "getCount", params = emptyList(), returnType = "Int"))
+
+        // WHEN
+        val file =
+            generateCompleteFake(
+                packageName = "com.example",
+                interfaceName = "Counter",
+                methods = methods,
+            )
+        val builder = CodeBuilder()
+        file.renderTo(builder)
+        val result = builder.build()
+
+        // THEN - no Flow member means the emptyFlow import must not be emitted
+        assertFalse(
+            result.contains("import kotlinx.coroutines.flow.emptyFlow"),
+            "Should not import emptyFlow when no member returns Flow",
+        )
+    }
+
+    @Test
     fun `GIVEN generateCompleteFake WHEN simple property THEN generates immutable constructor param`() {
         // GIVEN
         val properties = listOf(PropertySpec(name = "count", type = "Int", isStateFlow = false))

--- a/samples/kmp-multi-module/core/network/build.gradle.kts
+++ b/samples/kmp-multi-module/core/network/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.fakt.annotations)
+                implementation(libs.coroutines)
             }
         }
         commonTest {

--- a/samples/kmp-multi-module/core/network/src/commonMain/kotlin/com/rsicarelli/fakt/samples/kmpmultimodule/core/network/Network.kt
+++ b/samples/kmp-multi-module/core/network/src/commonMain/kotlin/com/rsicarelli/fakt/samples/kmpmultimodule/core/network/Network.kt
@@ -4,6 +4,7 @@
 package com.rsicarelli.fakt.samples.kmpmultimodule.core.network
 
 import com.rsicarelli.fakt.Fake
+import kotlinx.coroutines.flow.Flow
 
 /**
  * HTTP client interface for making network requests.
@@ -212,6 +213,14 @@ interface WebSocketConnection {
      * In a real implementation, this would likely return a Flow<String>.
      */
     suspend fun receive(): String?
+
+    /**
+     * Stream of incoming messages as a [Flow].
+     *
+     * The generated fake defaults this to `emptyFlow()`, which exercises the
+     * `kotlinx.coroutines.flow.emptyFlow` import in the generated file.
+     */
+    fun messages(): Flow<String>
 
     /**
      * Close this connection.

--- a/samples/kmp-multi-module/core/network/src/commonTest/kotlin/com/rsicarelli/fakt/samples/kmpmultimodule/core/network/NetworkTest.kt
+++ b/samples/kmp-multi-module/core/network/src/commonTest/kotlin/com/rsicarelli/fakt/samples/kmpmultimodule/core/network/NetworkTest.kt
@@ -3,6 +3,8 @@
 
 package com.rsicarelli.fakt.samples.kmpmultimodule.core.network
 
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -306,6 +308,35 @@ class WebSocketConnectionTest {
 
             // Then
             assertEquals("Server message", message)
+        }
+
+    @Test
+    fun `GIVEN WebSocketConnection fake WHEN messages not configured THEN should default to empty flow`() =
+        runTest {
+            // Given
+            val connection = fakeWebSocketConnection()
+
+            // When
+            val received = connection.messages().toList()
+
+            // Then
+            assertTrue(received.isEmpty())
+        }
+
+    @Test
+    fun `GIVEN WebSocketConnection fake WHEN messages configured THEN should emit configured values`() =
+        runTest {
+            // Given
+            val connection =
+                fakeWebSocketConnection {
+                    messages { flowOf("first", "second") }
+                }
+
+            // When
+            val received = connection.messages().toList()
+
+            // Then
+            assertEquals(listOf("first", "second"), received)
         }
 
     @Test


### PR DESCRIPTION
## Description
Fixes the missing `import kotlinx.coroutines.flow.emptyFlow` in generated fakes.

When a `@Fake` interface has a member returning `Flow<T>`, Fakt generates a default behavior of `emptyFlow()` but never adds the `kotlinx.coroutines.flow.emptyFlow` import, so the generated fake fails to compile. Users were working around it with a hand-written `FaktShim.kt`.

**Root cause:** the generated file's imports are collected only from the **types** in member signatures (`collectFqns` → `requiredImports`). Default-value *expressions* carry no import metadata. `emptyFlow` is a top-level **function**, not a type, so it was never collected. Collection defaults (`emptyList`/`emptySet`/`emptyMap`) avoid this because they live in the auto-imported `kotlin.collections` package, and `StateFlow` avoids it via a hardcoded import block in the generator — `Flow`/`emptyFlow` had no equivalent.

**Fix:** add an analogous rule in `generateCompleteFakeInternal` (`codegen-runtime/.../extensions/FakeGenerator.kt`). It resolves each member type with the same `DefaultValueResolver` the generator already uses and, when the resolved default contains `emptyFlow(`, adds the import. Detecting on the resolved expression (rather than a type-name guess) means nested cases like `Result<Flow<T>>` are covered, while `StateFlow`/`MutableStateFlow`/`SharedFlow` (which resolve to `MutableStateFlow(...)`/error) are not falsely matched.

Before → after for a `Flow<String>` member (from the regenerated sample fake):
```kotlin
import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
...
internal var messagesBehavior: (() -> Flow<String>) = { emptyFlow() }
```

## Related Issue
Fixes #128

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply` (`make format`)
- [ ] Linter passing: `./gradlew lintKotlin`
- [ ] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [ ] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context
Tests (TDD — written failing first, then made to pass):
- **Unit** — `FakeGeneratorTest.kt`: a method returning `Flow<User>` and a `Flow<User>` property each assert the `emptyFlow` import is present; a negative test asserts it is **absent** when no member uses Flow (guards against over-importing).
- **End-to-end** — no existing sample `@Fake` interface returned a bare `Flow<…>` (all used `StateFlow`), which is exactly why CI never caught this. Added a `messages(): Flow<String>` member to `WebSocketConnection` in the `kmp-multi-module` network sample plus two tests (default `emptyFlow()`, and a configured flow), and wired `libs.coroutines` into that module's `commonMain`.

Verification run locally: `make publish-local`, the regenerated `FakeWebSocketConnectionImpl` now contains `import kotlinx.coroutines.flow.emptyFlow`, `:core:network:jvmTest` and the full `:codegen-runtime:test` suite pass.

The broader alternative — attaching required imports to `CodeExpression.FunctionCall` so every default expression self-declares its imports — would eliminate this whole class of bug but touches the AST model, every strategy, and the collector; left as a possible follow-up rather than bundled into this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM5h7ypZr3bjHFoFKrfWNm)_