### PR TITLE
fix(release): stop sync-docs from corrupting the snapshot sample

### DIFF
--- a/.github/scripts/sync-docs-version.main.kts
+++ b/.github/scripts/sync-docs-version.main.kts
@@ -33,7 +33,7 @@ fun syncVersionCatalog(projectDir: File, newVersion: String) {
     if (!versionCatalogFile.exists()) return
 
     var content = versionCatalogFile.readText()
-    val pattern = Regex("""(fakt\s*=\s*)"[^"]*"""")
+    val pattern = Regex("""(fakt\s*=\s*)"[^"\n]*"""")
 
     if (pattern.containsMatchIn(content)) {
         content = content.replace(pattern, """$1"$newVersion"""")
@@ -47,7 +47,7 @@ fun syncFaktGradlePlugin(projectDir: File, newVersion: String) {
     if (!pluginFile.exists()) return
 
     var content = pluginFile.readText()
-    val pattern = Regex("""(public const val PLUGIN_VERSION: String = )"[^"]*"""")
+    val pattern = Regex("""(public const val PLUGIN_VERSION: String = )"[^"\n]*"""")
 
     if (pattern.containsMatchIn(content)) {
         content = content.replace(pattern, """$1"$newVersion"""")
@@ -64,19 +64,34 @@ fun syncDocumentationVersions(projectDir: File, newVersion: String) {
     syncVersionCatalog(projectDir, newVersion)
     syncFaktGradlePlugin(projectDir, newVersion)
 
+    // Files owned by bump-version.main.kts (updateSnapshotReferences): they intentionally pin the
+    // current <version>-SNAPSHOT, so this release-version sync must NOT touch them (it would strip
+    // the -SNAPSHOT suffix and, for the sample, its hardcoded `id(...) version "..."` line trips the
+    // catch-all regex below). See the release-script wiring.
+    val snapshotOwned = setOf(
+        "docs/get-started/snapshots.md",
+        "samples/snapshot-smoke/build.gradle.kts",
+    )
+    fun File.isSnapshotOwned(): Boolean {
+        val rel = relativeTo(projectDir).path.replace(File.separatorChar, '/')
+        return rel in snapshotOwned || rel.startsWith("samples/snapshot-smoke/")
+    }
+
     // Files to update
     val filesToUpdate = mutableListOf<File>()
 
     // Documentation files
     projectDir.walkTopDown().filter { file ->
         file.isFile && file.name.endsWith(".md") &&
-        !file.path.contains("/build/") && !file.path.contains("/.")
+        !file.path.contains("/build/") && !file.path.contains("/.") &&
+        !file.isSnapshotOwned()
     }.forEach { filesToUpdate.add(it) }
 
     // Sample build files that still use hardcoded versions
     projectDir.walkTopDown().filter { file ->
         file.isFile && file.name == "build.gradle.kts" &&
-        file.path.contains("/samples/")
+        file.path.contains("/samples/") &&
+        !file.isSnapshotOwned()
     }.forEach { filesToUpdate.add(it) }
 
     // Get current versions from version catalog for consistent documentation
@@ -94,15 +109,15 @@ fun syncDocumentationVersions(projectDir: File, newVersion: String) {
     // Patterns to replace (use version catalog versions for consistency)
     val replacementPatterns = listOf(
         // Plugin version declarations
-        Regex("""(id\("com\.rsicarelli\.fakt"\)\s+version\s+)"[^"]*"(\s*)""") to """$1"$newVersion"$2""",
+        Regex("""(id\("com\.rsicarelli\.fakt"\)\s+version\s+)"[^"\n]*"(\s*)""") to """$1"$newVersion"$2""",
 
         // Version catalog entries in docs
-        Regex("""(fakt\s*=\s*)"[^"]*"(\s*)""") to """$1"$newVersion"$2""",
-        Regex("""(kotlin\s*=\s*)"[^"]*"(\s*)""") to """$1"${versions["kotlin"]}"$2""",
-        Regex("""(coroutines\s*=\s*)"[^"]*"(\s*)""") to """$1"${versions["coroutines"]}"$2""",
+        Regex("""(fakt\s*=\s*)"[^"\n]*"(\s*)""") to """$1"$newVersion"$2""",
+        Regex("""(kotlin\s*=\s*)"[^"\n]*"(\s*)""") to """$1"${versions["kotlin"]}"$2""",
+        Regex("""(coroutines\s*=\s*)"[^"\n]*"(\s*)""") to """$1"${versions["coroutines"]}"$2""",
 
         // Maven coordinates (supports alpha/beta/stable formats)
-        Regex("""(com\.rsicarelli\.fakt:[\w-]+:)"[^"]*"""") to """$1"$newVersion"""",
+        Regex("""(com\.rsicarelli\.fakt:[\w-]+:)"[^"\n]*"""") to """$1"$newVersion"""",
         Regex("""(com\.rsicarelli\.fakt:[\w-]+:)[^"\s)]+(?=\s|\)|$)""") to """$1$newVersion""",
 
         // Documentation examples (supports alpha/beta/stable + optional)
@@ -110,10 +125,10 @@ fun syncDocumentationVersions(projectDir: File, newVersion: String) {
         Regex("""(Using Fakt\s+)[^\s+]+(\+?\s*)""") to """$1$newVersion+$2""",
 
         // Multiplatform version examples
-        Regex("""(kotlin\("multiplatform"\)\s+version\s+)"[^"]*"(\s*)""") to """$1"${versions["kotlin"]}"$2""",
+        Regex("""(kotlin\("multiplatform"\)\s+version\s+)"[^"\n]*"(\s*)""") to """$1"${versions["kotlin"]}"$2""",
 
         // Alpha/Beta/Stable specific patterns (more specific to avoid @OptIn collisions)
-        Regex("""(fakt.*version.*)"[^"]*"(\s*)""") to """$1"$newVersion"$2""",
+        Regex("""(fakt.*version.*)"[^"\n]*"(\s*)""") to """$1"$newVersion"$2""",
     )
 
     filesToUpdate.forEach { file ->

--- a/samples/snapshot-smoke/build.gradle.kts
+++ b/samples/snapshot-smoke/build.gradle.kts
@@ -4,7 +4,12 @@
 plugins {
     kotlin("jvm") version "2.4.10"
     // Apply the Fakt plugin straight from the published SNAPSHOT.
-    id("com.rsicarelli.fakt") version "1.0.0-beta11"1.0.0-beta11"com.rsicarelli.fakt:annotations:1.0.0-beta12-SNAPSHOT")
+    id("com.rsicarelli.fakt") version "1.0.0-beta12-SNAPSHOT"
+}
+
+dependencies {
+    // The @Fake annotation, at the same SNAPSHOT version.
+    implementation("com.rsicarelli.fakt:annotations:1.0.0-beta12-SNAPSHOT")
 
     // Generated fakes track call history via kotlinx-coroutines StateFlow, so it must be on the
     // classpath that compiles them (the test source set).


### PR DESCRIPTION
## Description
The "prepare for next version" commit [`f548d84`](https://github.com/rsicarelli/fakt/commit/f548d842f30dde7947f92bfbde10d9f8714c7be1) corrupted `samples/snapshot-smoke/build.gradle.kts`:

```kotlin
id("com.rsicarelli.fakt") version "1.0.0-beta11"1.0.0-beta11"com.rsicarelli.fakt:annotations:1.0.0-beta12-SNAPSHOT")
```

**Root cause.** `prepare-next-release.sh` runs `sync-docs-version.main.kts` (Step 1), which walks `samples/**/build.gradle.kts` and rewrites version strings. Its catch-all pattern
```
Regex("""(fakt.*version.*)"[^"]*"(\s*)""")
```
uses `[^"]*`, which **matches newlines**. On a hardcoded `id("com.rsicarelli.fakt") version "…"` line, greedy backtracking makes `"[^"]*"` span from the plugin-version closing quote all the way to the next quote (the `implementation(` line), collapsing the `plugins {}` block, `}`, `dependencies {`, the comment, and `implementation("` into a single mangled line.

It never triggered before because every *other* sample uses the version catalog (`alias(libs.plugins.fakt)`), so no sample had a literal `id(...) version "..."` line for the pattern to match. `snapshot-smoke` is the first (it's standalone and can't use the catalog). `docs/get-started/snapshots.md` escaped only by luck (an unrelated `/.`-path check excludes `.md` files), and `bump-version` set its version correctly.

There's also a **semantic** issue: `sync-docs` targets the *released* version, but these two files are snapshot-pinned and already owned by `bump-version.main.kts` (`updateSnapshotReferences`), which sets them to `<version>-SNAPSHOT`. `sync-docs` shouldn't touch them at all.

## Fix
1. **Exclude the snapshot-pinned files** (`docs/get-started/snapshots.md`, `samples/snapshot-smoke/`) from `sync-docs-version.main.kts` — they're owned by `bump-version`'s `updateSnapshotReferences`. This is the primary fix and gives clean ownership.
2. **Harden the regexes** — every "value between quotes" pattern goes from `"[^"]*"` to `"[^"\n]*"`, so a version match can never span lines again for any future hardcoded sample. (Extraction patterns `([^"]+)` for reading the catalog are unchanged.)
3. **Restore** `samples/snapshot-smoke/build.gradle.kts` to the correct content at the current version (`1.0.0-beta12-SNAPSHOT`).

## Verification
Simulated the exact release-script regexes (no `kotlin` CLI locally):
- The **hardened** catch-all applied to the previously-corruptible sample now updates the plugin version cleanly and **preserves the line count** (no collapse).
- With the **exclusion** in place, `sync-docs` skips `snapshot-smoke` and `snapshots.md` entirely, leaving them to `bump-version`.
- Confirmed the value patterns became `[^"\n]*` while the `([^"]+)` catalog-extraction patterns are untouched.

## Related
Fixes the fallout from #132 (the snapshot guide + proof sample) interacting with the release script.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor/Performance/Build (release script)

## Pre-Submission Checklist
- [x] Corrupted sample restored and structurally identical to the previously-validated one
- [x] Release-script regex hardened + snapshot files excluded (verified by simulation)
- [x] No breaking changes

## Additional Context
Out of scope but worth a follow-up: the `!file.path.contains("/.")` check in `sync-docs` (meant to skip `.git`/`.claude`) currently excludes **all** `.md` files because `projectDir` is built from `File(".")`, so `.md` docs are never version-synced. Not touched here to keep this fix focused on the corruption.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM5h7ypZr3bjHFoFKrfWNm)_