### PR TITLE
feat(gradle): make cache-correct generation the default

### DIFF
--- a/.claude/docs/implementation/architecture/ARCHITECTURE.md
+++ b/.claude/docs/implementation/architecture/ARCHITECTURE.md
@@ -11,13 +11,13 @@ Fakt is a Kotlin compiler plugin that generates type-safe test fakes from `@Fake
 
 The plugin has **two emission paths**, selected by `SourceSetContext.emitPhase`:
 
-- **IR emission (legacy default)** — the in-process plugin runs inside `compileKotlin*`; the FIR
-  phase validates and the IR phase generates.
-- **FIR emission (`fakt.useExperimentalGenerateTask=true`)** — a cacheable `FaktGenerateTask`
-  hosts the compiler in a Gradle Worker and the FIR checkers themselves emit the fakes
-  (byte-identical to IR emission, locked by `FirIrEmissionParityTest`). See
-  [metadata-producer-fir-emission.md](metadata-producer-fir-emission.md). Flipping the default
-  (backlog P8) and removing the legacy path (P9) are deferred follow-ups.
+- **FIR emission (default)** — a cacheable `FaktGenerateTask` hosts the compiler in a Gradle
+  Worker and the FIR checkers themselves emit the fakes (byte-identical to IR emission, locked by
+  `FirIrEmissionParityTest`). See
+  [metadata-producer-fir-emission.md](metadata-producer-fir-emission.md).
+- **IR emission (legacy, `fakt.useExperimentalGenerateTask=false`)** — the in-process plugin runs
+  inside `compileKotlin*`; the FIR phase validates and the IR phase generates. Kept as an opt-out
+  until it is removed (backlog P9).
 
 ### Design Principles
 
@@ -365,7 +365,7 @@ String-based code generation with a type-safe DSL was chosen over pure IR node m
 
 ## Cache-Correct Generation: `FaktGenerateTask` (issue #79)
 
-**Guard**: `fakt.useExperimentalGenerateTask` (default `false`).
+**Guard**: `fakt.useExperimentalGenerateTask` (default `true`; `false` opts back into the legacy in-process path).
 
 The legacy in-process path writes generated `.kt` files as a *side effect* of `compileKotlin*`, so
 a warm Gradle build cache restores the compilation without them. The cache-correct path makes the
@@ -385,7 +385,9 @@ files real task outputs:
   and keeps emitting at IR.
 - **Routing** (`FaktGradleSubplugin.cacheCorrectDecision`): commonMain → producer; JVM/Android
   platform mains → consumers; Native/JS/Wasm platform mains → LEGACY_HYBRID (in-process plugin,
-  ordered after the producer); other metadata compilations → suppressed.
+  ordered after the producer); other metadata compilations → suppressed. Single-target KMP projects
+  (one non-`metadata` target) have no `commonMain` compilation to produce from, so every compilation
+  there routes to LEGACY.
 
 Full design, driver invocation reference, parity contract, and hazards:
 [metadata-producer-fir-emission.md](metadata-producer-fir-emission.md).
@@ -510,9 +512,9 @@ fakt/
 Fakt implements a **two-phase FIR → IR compilation pipeline** with **type-safe DSL-based code generation**:
 
 ✅ **FIR Phase** - Validates `@Fake` annotations, stores metadata; emits directly when `emitPhase == FIR`
-✅ **IR Phase** - Transforms metadata, generates code (legacy default path)
+✅ **IR Phase** - Transforms metadata, generates code (legacy opt-out path)
 ✅ **One emitter, two drivers** - `codegen-runtime` renders for both phases; `KotlinMetadataCompiler` (common producers) and `K2JVMCompiler` (JVM paths) drive the worker
-✅ **Cache-correct** - `FaktGenerateTask` makes generated fakes real, relocatable task outputs (behind the flag; P8/P9 deferred)
+✅ **Cache-correct** - `FaktGenerateTask` makes generated fakes real, relocatable task outputs (the default since P8; P9 — removing the legacy path — deferred)
 ✅ **Type-Safe DSL** - Builders create immutable models
 ✅ **String Rendering** - Models render to `.kt` files
 ✅ **Transparent** - Generated code is readable and debuggable

--- a/.claude/docs/implementation/architecture/ARCHITECTURE.md
+++ b/.claude/docs/implementation/architecture/ARCHITECTURE.md
@@ -386,8 +386,9 @@ files real task outputs:
 - **Routing** (`FaktGradleSubplugin.cacheCorrectDecision`): commonMain → producer; JVM/Android
   platform mains → consumers; Native/JS/Wasm platform mains → LEGACY_HYBRID (in-process plugin,
   ordered after the producer); other metadata compilations → suppressed. Single-target KMP projects
-  (one non-`metadata` target) have no `commonMain` compilation to produce from, so every compilation
-  there routes to LEGACY.
+  (one non-`metadata` target) have no `commonMain` compilation to produce from, and Android modules
+  on AGP's built-in Kotlin (no `org.jetbrains.kotlin.android`) expose no readable Kotlin source
+  sets, so every compilation of either routes to LEGACY.
 
 Full design, driver invocation reference, parity contract, and hazards:
 [metadata-producer-fir-emission.md](metadata-producer-fir-emission.md).

--- a/.claude/docs/implementation/architecture/kmp-optimization-strategy.md
+++ b/.claude/docs/implementation/architecture/kmp-optimization-strategy.md
@@ -21,9 +21,9 @@ in no released `FaktPluginExtension`, and the design it described was replaced b
 | Build-cache correctness of generated fakes | Generated `.kt` files are declared task outputs of `FaktGenerateTask` | [metadata-producer-fir-emission.md](metadata-producer-fir-emission.md) §7 |
 | Overall plugin architecture | Two emit phases (FIR for the worker paths, IR for the legacy in-process path), two drivers | [ARCHITECTURE.md](ARCHITECTURE.md) |
 
-Everything above ships behind `fakt.useExperimentalGenerateTask` (default `false`). Flipping the
-default (backlog P8) and removing the legacy in-process path (P9) are tracked as follow-ups to the
-issue #79 branch.
+Everything above is selected by `fakt.useExperimentalGenerateTask`, which now defaults to `true`
+(backlog P8, landed). Removing the legacy in-process path (P9) is still tracked as a follow-up to
+the issue #79 branch; until then, `false` opts back into it.
 
 ## Still-valid background from the original document
 

--- a/.claude/docs/implementation/architecture/metadata-producer-fir-emission.md
+++ b/.claude/docs/implementation/architecture/metadata-producer-fir-emission.md
@@ -1,14 +1,15 @@
 # Metadata-Driver Producer + FIR-Phase Emission (Issue #79)
 
-**Status:** Implemented on `feat/79-metadata-producer` — emitPhase contract, FirTypeRenderer +
-parity gate, FIR emitter, metadata driver, FIR-unified worker paths, and the no-JVM-target routing
-(§8 is the live table) all landed; P8 (flip default) / P9 (remove legacy) remain deferred
+**Status:** Implemented — emitPhase contract, FirTypeRenderer + parity gate, FIR emitter, metadata
+driver, FIR-unified worker paths, and the no-JVM-target routing (§8 is the live table) all landed.
+**P8 (flip default) has landed**: `fakt.useExperimentalGenerateTask` now defaults to `true`. P9
+(remove the legacy in-process path) remains deferred
 **Last Updated:** July 2026
 **Research basis:** [issue-79-cache-correct-kmp-research.md](../research/issue-79-cache-correct-kmp-research.md)
 (9-part investigation, verified against Kotlin `build-2.3.21-release-298` and KSP 2.3.0-290 primary source)
-**Guard:** everything in this design ships behind `fakt.useExperimentalGenerateTask` (default `false`,
-`FaktPluginExtension.kt`). Flipping the default (backlog P8) and removing the legacy path (P9) are
-explicitly **out of scope** for this branch.
+**Guard:** everything in this design is selected by `fakt.useExperimentalGenerateTask` (default
+`true`, `FaktPluginExtension.kt`). Setting it to `false` opts back into the legacy in-process path,
+which stays reachable until it is removed (backlog P9).
 
 ---
 
@@ -279,6 +280,7 @@ branch is **deleted** (the producer no longer needs a JVM classpath):
 |---|---|---|
 | Single-platform JVM `main` | REGISTER_PRODUCER | K2JVM, FIR-emit |
 | Single-platform non-JVM | LEGACY | in-process, IR |
+| Any compilation of a **single-target KMP** project | LEGACY | in-process, IR |
 | KMP `commonMain` (any target set, **incl. no JVM/Android target**) | REGISTER_PRODUCER | **KotlinMetadataCompiler**, FIR-emit |
 | KMP other `platformType == common` metadata compilations | SUPPRESS | — |
 | KMP JVM/Android platform `main` | REGISTER_CONSUMER | K2JVM, FIR-emit; ancestors ride as `-Xcommon-sources` analysis-only (`emitSourceSets` restricts emission to the platform source set) |
@@ -287,6 +289,18 @@ branch is **deleted** (the producer no longer needs a JVM classpath):
 Platform-declared `@Fake` in `nativeMain`/`jsMain`/`wasmJsMain`/`iosMain` stays on LEGACY_HYBRID —
 unchanged, correct, but not cache-correct (no Native/JS driver in the embeddable). Out of scope here;
 CI presence checks continue to lock it.
+
+**Single-target KMP** (exactly one non-`metadata` target, e.g. `kotlin { jvm() }`) is a shape the
+cache-correct path cannot serve: KGP never creates the per-source-set `commonMain` compilation for
+it, exposing only the legacy metadata `main` compilation — which carries `commonMain` as its default
+source set but resolves an **empty** compile classpath, so `KotlinMetadataCompiler` cannot be driven
+over it. The lone platform main is a source-partitioned consumer that emits only its own source set,
+so nothing would own the project's common fakes and every commonMain `@Fake` would be dropped. Those
+projects therefore route entirely to LEGACY — correct, just not cache-correct. Detected by counting
+non-`common` targets, **not** by looking the compilation up: KGP creates the metadata target's
+per-source-set compilations *after* resolving subplugins for every platform main, so the lookup
+reports "absent" for multi-target projects too. Locked by `samples/compat/*` (all single-target KMP)
+and a routing test in `FaktGradleSubpluginFlagResolutionTest`.
 
 ## 9. Known hazards & out-of-scope
 
@@ -301,9 +315,10 @@ CI presence checks continue to lock it.
   cache key, and `FaktGenerateTaskWiring.register` sources them from the `fakt { }` extension. The FIR
   emitter already resolved modes exactly as the IR path does, so FIR/IR parity was never the gap — it was
   purely the worker-vs-legacy option payload, now closed.
-- **Out of scope:** flipping `useExperimentalGenerateTask` default (P8); removing the legacy path (P9);
-  cache-correct platform-declared fakes for Native/JS/Wasm; `actual typealias` and `@Fake`-on-expect
-  scenarios (checker rejects `FAKE_CANNOT_BE_EXPECT` by design).
+- **Out of scope:** removing the legacy path (P9); cache-correct platform-declared fakes for
+  Native/JS/Wasm; `actual typealias` and `@Fake`-on-expect scenarios (checker rejects
+  `FAKE_CANNOT_BE_EXPECT` by design). Flipping the `useExperimentalGenerateTask` default (P8) has
+  since landed — the default is `true`.
 
 ## 10. Verification map
 

--- a/.claude/docs/implementation/architecture/metadata-producer-fir-emission.md
+++ b/.claude/docs/implementation/architecture/metadata-producer-fir-emission.md
@@ -281,6 +281,7 @@ branch is **deleted** (the producer no longer needs a JVM classpath):
 | Single-platform JVM `main` | REGISTER_PRODUCER | K2JVM, FIR-emit |
 | Single-platform non-JVM | LEGACY | in-process, IR |
 | Any compilation of a **single-target KMP** project | LEGACY | in-process, IR |
+| Any compilation of an **Android module without KGP** (AGP built-in Kotlin) | LEGACY | in-process, IR |
 | KMP `commonMain` (any target set, **incl. no JVM/Android target**) | REGISTER_PRODUCER | **KotlinMetadataCompiler**, FIR-emit |
 | KMP other `platformType == common` metadata compilations | SUPPRESS | — |
 | KMP JVM/Android platform `main` | REGISTER_CONSUMER | K2JVM, FIR-emit; ancestors ride as `-Xcommon-sources` analysis-only (`emitSourceSets` restricts emission to the platform source set) |
@@ -301,6 +302,17 @@ non-`common` targets, **not** by looking the compilation up: KGP creates the met
 per-source-set compilations *after* resolving subplugins for every platform main, so the lookup
 reports "absent" for multi-target projects too. Locked by `samples/compat/*` (all single-target KMP)
 and a routing test in `FaktGradleSubpluginFlagResolutionTest`.
+
+**Android on AGP's built-in Kotlin** (AGP 9+, which rejects `org.jetbrains.kotlin.android`) is the
+second such shape. There the `KotlinCompilation`s handed to `applyToCompilation` carry
+`KotlinSourceSet`s whose `kotlin.srcDirs` are **empty** — AGP keeps sources in its own variant model
+— so a producer resolves zero sources, runs NO-SOURCE and silently emits nothing. Measured on
+`samples/compat-agp/agp-9.0`: `srcDirs=[]` on every compilation even at `projectsEvaluated`, while
+the AGP 8.x + KGP cells report real directories. Detected by plugin id (`com.android.*` applied and
+`org.jetbrains.kotlin.android` not), never by probing `srcDirs`, which is unreadable this early for
+every project. The gate sits on both the `apply` branch (the legacy path needs
+`SourceSetConfigurator.configureSourceSets()` to wire its output) and `cacheCorrectDecision`. Locked
+by the `compat-agp/agp-9.0` CI cell and `FaktKotlinSourceSetModelTest`.
 
 ## 9. Known hazards & out-of-scope
 

--- a/.claude/docs/implementation/research/issue-79-cache-correct-kmp-research.md
+++ b/.claude/docs/implementation/research/issue-79-cache-correct-kmp-research.md
@@ -1,6 +1,10 @@
 # Issue #79 — Deep Research Plan: cracking cache-correct KMP fakes (the expect/actual blocker)
 
-**Status:** research phase (pre-implementation). Internal control doc.
+**Status:** historical — research phase (pre-implementation). Internal control doc, kept for the
+reasoning trail. The blocker described below was solved by the metadata-driver producer
+([metadata-producer-fir-emission.md](../architecture/metadata-producer-fir-emission.md)), and P8 has
+since landed: `fakt.useExperimentalGenerateTask` defaults to `true`. Statements here about what
+"cannot" be done yet describe the state at research time, not today's.
 **Target Kotlin:** 2.3.20 (worker pins `FAKT_KOTLIN_VERSION = "2.3.20"`).
 **Owner artifact for status:** GitHub issue #79.
 

--- a/.github/scripts/cache-correctness-check.sh
+++ b/.github/scripts/cache-correctness-check.sh
@@ -20,8 +20,8 @@
 #
 # Non-drivable platform mains (Native/JS/Wasm) generate their platform-specific fakes via the
 # in-process plugin, which is not cacheable by construction. Those fakes must still never be dropped,
-# so when FAKT_PRESENCE_TASKS is set this script additionally runs those compile tasks (with the
-# flag) and asserts every fake named in FAKT_PRESENCE_FAKES physically exists — present, not cached.
+# so when FAKT_PRESENCE_TASKS is set this script additionally runs those compile tasks and asserts
+# every fake named in FAKT_PRESENCE_FAKES physically exists — present, not cached.
 #
 # Usage: cache-correctness-check.sh <project-path> [producer-task...]
 #        (producer task defaults to `faktGenerateMetadataCommonMain`)
@@ -37,8 +37,9 @@ if [ "${#PRODUCER_TASKS[@]}" -eq 0 ]; then
   PRODUCER_TASKS=("faktGenerateMetadataCommonMain")
 fi
 
-FLAG="-Pfakt.useExperimentalGenerateTask=true"
-GRADLE=(./gradlew -p "$PROJECT_PATH" "$FLAG" --build-cache --no-configuration-cache --console=plain)
+# No -Pfakt.useExperimentalGenerateTask here on purpose: the cache-correct path is Fakt's default,
+# so this contract must hold for the configuration users actually get.
+GRADLE=(./gradlew -p "$PROJECT_PATH" --build-cache --no-configuration-cache --console=plain)
 
 count_fakes() {
   find "$PROJECT_PATH" -path '*build/generated*' -name 'Fake*.kt' 2>/dev/null | wc -l | tr -d ' '

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -296,7 +296,7 @@ jobs:
       fail-fast: false
       matrix:
         agp-version:
-          - "8.11" # floor: Android test fixtures on AGP 8.x (Gradle 8.13, behind the experimental flag)
+          - "8.11" # floor: Android test fixtures on AGP 8.x (Gradle 8.13)
           - "8.12" # current: matches the repo's pinned AGP (Gradle 9.0)
           - "9.0" # forward: AGP 9.0, testFixtures Kotlin support without the experimental flag (Gradle 9.1)
     steps:

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -136,9 +136,9 @@ Run Gradle build to generate the fake:
 Fakt generates `FakeAnalyticsImpl` in `build/generated/fakt/commonTest/kotlin/com/example/`.
 
 !!! tip "Compilation Trigger"
-    Fakt hooks into Kotlin compilation tasks. Running any compile task
-    (`:compileKotlin`, `:build`, or IDE build/compile/assemble) triggers
-    Fakt generation automatically.
+    Fakt registers `faktGenerate*` tasks that run ahead of the Kotlin compilation
+    tasks that consume their output. Running any compile task (`:compileKotlin`,
+    `:build`, or IDE build/compile/assemble) triggers Fakt generation automatically.
 
 ---
 

--- a/docs/user-guide/performance.md
+++ b/docs/user-guide/performance.md
@@ -24,6 +24,12 @@ compileKotlinAndroid: 1ms (121 from cache)
 compileKotlinIosX64:  1ms (121 from cache)
 ```
 
+## Gradle Build Cache
+
+Generation runs in dedicated `faktGenerate*` tasks whose generated `.kt` files are declared task
+outputs, so a warm Gradle build cache restores the fakes along with the compilation that uses them.
+See [Cache-Correct Generation](plugin-configuration.md#cache-correct-generation).
+
 ---
 
 ## Telemetry Configuration

--- a/docs/user-guide/plugin-configuration.md
+++ b/docs/user-guide/plugin-configuration.md
@@ -414,12 +414,19 @@ Every `@Fake` is always generated — none are dropped. JS/Wasm are not cache-co
 cannot be (its compiler is not embeddable, so it can't run in a Gradle task); those platform fakes
 are produced by the in-process plugin instead.
 
-!!! note "Single-target multiplatform projects"
-    A multiplatform project that declares exactly one target (`kotlin { jvm() }` and nothing else)
-    keeps the in-process path. Kotlin does not give such a project a `commonMain` compilation to
-    generate from, so there is nothing to make cache-correct. Fakes are still generated for every
-    `@Fake`; they just aren't declared task outputs. Adding a second target moves the project onto
-    the cache-correct path automatically.
+!!! note "Project shapes that keep the in-process path"
+    Two shapes fall back to generating inside `compileKotlin*`. Fakes are still generated for every
+    `@Fake` in both — they just aren't declared task outputs, so a warm build cache can restore a
+    compilation without them.
+
+    - **Single-target multiplatform projects** (`kotlin { jvm() }` and nothing else). Kotlin does
+      not give such a project a `commonMain` compilation to generate from, so there is nothing to
+      make cache-correct. Adding a second target moves the project onto the cache-correct path
+      automatically.
+    - **Android modules on AGP's built-in Kotlin support** (AGP 9+, where `org.jetbrains.kotlin.android`
+      is no longer applied). AGP keeps Kotlin sources in its own variant model rather than the
+      source sets Fakt reads. Android modules that apply the Kotlin Android plugin — every AGP 8.x
+      build — stay on the cache-correct path.
 
 **Default:** `true`.
 

--- a/docs/user-guide/plugin-configuration.md
+++ b/docs/user-guide/plugin-configuration.md
@@ -395,27 +395,13 @@ For complete multi-module documentation, see **[Multi-Module Guide](multi-module
 
 ---
 
-## Cache-Correct Generation (Experimental)
+## Cache-Correct Generation
 
-By default Fakt generates fakes inside `compileKotlin*` as a side effect. The experimental
-cache-correct path instead runs generation in a dedicated, cacheable Gradle task so the generated
-`.kt` files are declared task outputs — when Gradle's build cache restores a compilation, the fakes
-come back with it.
+Fakt generates fakes in dedicated, cacheable `faktGenerate*` Gradle tasks. The generated `.kt` files
+are declared task outputs, so when Gradle's build cache restores a compilation the fakes come back
+with it — no empty or missing fakes on a cache hit.
 
-Opt in via the extension or a Gradle property (the property wins, so you can always opt out with
-`-Pfakt.useExperimentalGenerateTask=false`):
-
-```kotlin
-fakt {
-    useExperimentalGenerateTask.set(true)
-}
-```
-
-```bash
-gradle build -Pfakt.useExperimentalGenerateTask=true
-```
-
-**Support matrix (under the flag):**
+**Support matrix:**
 
 | `@Fake` declared in        | Generated | Cache-correct |
 |----------------------------|-----------|---------------|
@@ -428,7 +414,36 @@ Every `@Fake` is always generated — none are dropped. JS/Wasm are not cache-co
 cannot be (its compiler is not embeddable, so it can't run in a Gradle task); those platform fakes
 are produced by the in-process plugin instead.
 
-**Default:** `false` (the in-process path runs unchanged).
+!!! note "Single-target multiplatform projects"
+    A multiplatform project that declares exactly one target (`kotlin { jvm() }` and nothing else)
+    keeps the in-process path. Kotlin does not give such a project a `commonMain` compilation to
+    generate from, so there is nothing to make cache-correct. Fakes are still generated for every
+    `@Fake`; they just aren't declared task outputs. Adding a second target moves the project onto
+    the cache-correct path automatically.
+
+**Default:** `true`.
+
+### Opting out
+
+The previous behaviour — generation running inside `compileKotlin*` as a side effect — is still
+available. Turn it off via the extension or a Gradle property (the property wins over the extension,
+so a command-line opt-out always applies):
+
+```kotlin
+fakt {
+    useExperimentalGenerateTask.set(false)
+}
+```
+
+```bash
+gradle build -Pfakt.useExperimentalGenerateTask=false
+```
+
+!!! warning "Temporary escape hatch"
+    On the in-process path the generated fakes are not declared task outputs, so a warm build cache
+    can restore a compilation without them. The path is kept only as an escape hatch and will be
+    removed in a future release — please [open an issue](https://github.com/rsicarelli/fakt/issues)
+    if you need it.
 
 ---
 

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -49,6 +49,46 @@ private fun hasCommonMainProducer(
 ): Boolean = kmp.targets.count { !it.platformType.name.equals("common", ignoreCase = true) } > 1
 
 /**
+ * Whether this project exposes a Kotlin source-set model the cache-correct producer can read.
+ *
+ * AGP 9 ships built-in Kotlin support and rejects KGP's `org.jetbrains.kotlin.android` plugin. In
+ * that setup the `KotlinCompilation`s handed to [FaktGradleSubplugin.applyToCompilation] carry
+ * `KotlinSourceSet`s whose `kotlin.srcDirs` stay **empty** — AGP keeps the sources in its own
+ * variant model — so a `FaktGenerateTask` producer resolves zero sources, runs as NO-SOURCE and
+ * silently generates nothing. Measured on `samples/compat-agp/agp-9.0`: every compilation reports
+ * `srcDirs=[]` even at `projectsEvaluated`, while the AGP 8.x + KGP cells report real directories.
+ * Those projects stay on the in-process plugin ([CacheCorrectDecision.LEGACY]) — correct, just not
+ * cache-correct.
+ *
+ * Keyed off the applied plugin ids rather than probing `srcDirs`, for the same reason
+ * [hasCommonMainProducer] counts targets: source sets are not reliably populated at the point the
+ * routing decision runs, so an emptiness probe would send healthy KGP projects down the legacy path
+ * too. Plugin ids are settled in the `plugins { }` block, long before subplugin resolution.
+ */
+private fun hasKotlinSourceSetModel(project: Project): Boolean =
+    hasReadableKotlinSourceSets(
+        hasAndroidPlugin =
+            project.plugins.hasPlugin("com.android.library") ||
+                project.plugins.hasPlugin("com.android.application"),
+        hasKotlinAndroidPlugin = project.plugins.hasPlugin("org.jetbrains.kotlin.android"),
+    )
+
+/**
+ * Pure decision behind [hasKotlinSourceSetModel]. An Android module populates the KGP source-set
+ * model only when KGP's own `org.jetbrains.kotlin.android` plugin is applied; on AGP's built-in
+ * Kotlin support it does not, and `srcDirs` stays empty. Non-Android projects always have one.
+ * Extracted as a `Project`-free function so the truth table is unit-testable without a Gradle
+ * project (mirrors [shouldEnableTestFixtures]).
+ *
+ * @param hasAndroidPlugin whether `com.android.library` / `com.android.application` is applied.
+ * @param hasKotlinAndroidPlugin whether KGP's `org.jetbrains.kotlin.android` is applied.
+ */
+internal fun hasReadableKotlinSourceSets(
+    hasAndroidPlugin: Boolean,
+    hasKotlinAndroidPlugin: Boolean,
+): Boolean = !hasAndroidPlugin || hasKotlinAndroidPlugin
+
+/**
  * Pure decision for whether Fakt should route generated fakes into a `testFixtures` source set.
  *
  * Test-fixtures mode requires the opt-in flag AND a build that actually has a `testFixtures`
@@ -219,7 +259,14 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                 target.logger.info("Fakt: Generator mode enabled - generating fakes")
 
                 val useTestFixtures = resolveTestFixturesMode(target, extension)
-                if (resolveExperimentalGenerateTaskFlag(target, extension)) {
+                // `hasKotlinSourceSetModel` gates the whole cache-correct branch, not just the
+                // per-compilation routing below: a project without a readable Kotlin source-set
+                // model falls back to the in-process plugin, and that path needs the legacy source
+                // set wiring to compile the fakes it writes.
+                if (
+                    resolveExperimentalGenerateTaskFlag(target, extension) &&
+                        hasKotlinSourceSetModel(target)
+                ) {
                     target.logger.info(
                         "Fakt: cache-correct generation enabled (the default) — registering " +
                             "FaktGenerateTask per compilation; the in-process compiler-plugin " +
@@ -547,7 +594,9 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
      * fakes.
      *
      * A single-target KMP project has no per-source-set `commonMain` compilation at all (see
-     * [hasCommonMainProducer]); every one of its compilations stays on the in-process plugin.
+     * [hasCommonMainProducer]), and an Android project on AGP's built-in Kotlin exposes no readable
+     * Kotlin source sets (see [hasKotlinSourceSetModel]); every compilation of either stays on the
+     * in-process plugin.
      */
     private fun cacheCorrectDecision(
         kotlinCompilation: KotlinCompilation<*>
@@ -563,6 +612,7 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         // legacy `main` compilation plus shared-source-set metadata compilations (all platformType
         // `common`, no IR phase) — those must be suppressed, not turned into a second producer.
         return when {
+            !hasKotlinSourceSetModel(kotlinCompilation.project) -> CacheCorrectDecision.LEGACY
             kmp == null ->
                 if (isDrivablePlatform(platformType)) CacheCorrectDecision.REGISTER_PRODUCER
                 else CacheCorrectDecision.LEGACY

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubplugin.kt
@@ -26,6 +26,29 @@ private fun isDrivablePlatform(platformTypeName: String): Boolean =
     }
 
 /**
+ * Whether this KMP project gets a per-source-set `commonMain` metadata compilation — the one the
+ * cache-correct path drives as the common producer. True exactly when the project declares more
+ * than one real (non-`metadata`) target.
+ *
+ * A **single-target** KMP project gets no such compilation: KGP exposes only the legacy metadata
+ * `main` compilation, which carries `commonMain` as its default source set but resolves an empty
+ * compile classpath, so `KotlinMetadataCompiler` cannot be driven over it. Nothing else can own
+ * that project's common fakes either — the single platform main is a source-partitioned consumer
+ * that emits only its own source set — so without this check every `@Fake` declared in `commonMain`
+ * would be silently dropped. Such projects stay on the in-process plugin (the LEGACY routing
+ * decision): correct, just not cache-correct.
+ *
+ * Counting targets rather than looking the compilation up is deliberate. KGP creates the metadata
+ * target's per-source-set compilations *after* it has resolved subplugins for every platform main,
+ * so `commonMain` is still absent while `jvmMain` is being decided and the lookup would report
+ * single-target for every project. The target set, by contrast, is complete before the routing
+ * decision runs — KGP resolves subplugins once the `kotlin { }` block has run.
+ */
+private fun hasCommonMainProducer(
+    kmp: org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+): Boolean = kmp.targets.count { !it.platformType.name.equals("common", ignoreCase = true) } > 1
+
+/**
  * Pure decision for whether Fakt should route generated fakes into a `testFixtures` source set.
  *
  * Test-fixtures mode requires the opt-in flag AND a build that actually has a `testFixtures`
@@ -169,9 +192,9 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     /**
      * Creates the `fakt { }` extension and, after evaluation, routes the project: collector mode
      * registers [FakeCollectorTask]s for [FaktPluginExtension.collectFrom]; generator mode either
-     * wires legacy source sets ([SourceSetConfigurator]) or, with the experimental flag on,
-     * prepares the worker configurations — per-compilation [FaktGenerateTask] registration happens
-     * later in [applyToCompilation].
+     * prepares the worker configurations for the default cache-correct path or, when it is opted
+     * out of, wires the legacy source sets ([SourceSetConfigurator]) — per-compilation
+     * [FaktGenerateTask] registration happens later in [applyToCompilation].
      */
     @OptIn(ExperimentalFaktMultiModule::class)
     override fun apply(target: Project) {
@@ -198,8 +221,10 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                 val useTestFixtures = resolveTestFixturesMode(target, extension)
                 if (resolveExperimentalGenerateTaskFlag(target, extension)) {
                     target.logger.info(
-                        "Fakt: useExperimentalGenerateTask=true — registering FaktGenerateTask " +
-                            "per compilation; the in-process compiler-plugin path stays disabled."
+                        "Fakt: cache-correct generation enabled (the default) — registering " +
+                            "FaktGenerateTask per compilation; the in-process compiler-plugin " +
+                            "path stays disabled. Opt out with " +
+                            "-Pfakt.useExperimentalGenerateTask=false."
                     )
                     ensureFaktConfigurations(target)
                     // Non-drivable KMP platform mains (Native/JS/Wasm) keep generating their own
@@ -217,11 +242,13 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     }
 
     /**
-     * Resolves the experimental flag, with the Gradle property `fakt.useExperimentalGenerateTask`
-     * taking precedence over the `fakt { }` extension. When the property is set to a strict boolean
-     * it wins outright — so `-Pfakt.useExperimentalGenerateTask=false` can turn the path off even
-     * when the build script sets the extension to `true`. Otherwise the extension convention
-     * decides.
+     * Resolves the cache-correct generate-task flag, with the Gradle property
+     * `fakt.useExperimentalGenerateTask` taking precedence over the `fakt { }` extension. When the
+     * property is set to a strict boolean it wins outright — so
+     * `-Pfakt.useExperimentalGenerateTask=false` can turn the path off even when the build script
+     * sets the extension to `true`. Otherwise the extension convention decides, and that convention
+     * is `true`: the cache-correct path is the default and the legacy in-process path is the
+     * opt-out.
      */
     private fun resolveExperimentalGenerateTaskFlag(
         project: Project,
@@ -518,6 +545,9 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
      * in-process plugin ([CacheCorrectDecision.LEGACY_HYBRID]): its platform-specific fakes are
      * generated (not cache-correct), while the common producer still owns the cache-correct common
      * fakes.
+     *
+     * A single-target KMP project has no per-source-set `commonMain` compilation at all (see
+     * [hasCommonMainProducer]); every one of its compilations stays on the in-process plugin.
      */
     private fun cacheCorrectDecision(
         kotlinCompilation: KotlinCompilation<*>
@@ -536,6 +566,7 @@ public class FaktGradleSubplugin : KotlinCompilerPluginSupportPlugin {
             kmp == null ->
                 if (isDrivablePlatform(platformType)) CacheCorrectDecision.REGISTER_PRODUCER
                 else CacheCorrectDecision.LEGACY
+            !hasCommonMainProducer(kmp) -> CacheCorrectDecision.LEGACY
             kotlinCompilation.name == COMMON_MAIN_COMPILATION ->
                 CacheCorrectDecision.REGISTER_PRODUCER
             platformType.equals("common", ignoreCase = true) -> CacheCorrectDecision.SUPPRESS

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtension.kt
@@ -190,16 +190,17 @@ constructor(objects: ObjectFactory, private val project: Project) {
         objects.property(Boolean::class.java).convention(false)
 
     /**
-     * Opt in to the cache-correct `FaktGenerateTask` codepath that hosts Fakt's compiler in a
-     * Gradle Worker outside `compileKotlin*`. Fixes issue #79 — when Gradle's build cache restores
+     * Controls the cache-correct `FaktGenerateTask` codepath that hosts Fakt's compiler in a Gradle
+     * Worker outside `compileKotlin*`. Fixes issue #79 — when Gradle's build cache restores
      * `compileKotlin*`, the generated `.kt` files come back too because they're declared task
      * outputs rather than side-effect writes.
      *
-     * When enabled, the in-process compiler-plugin registration is disabled and a
+     * When enabled (the default), the in-process compiler-plugin registration is disabled and a
      * `FaktGenerateTask` is registered per compilation, with its output wired into the matching
-     * test source set.
+     * test source set. When set to `false`, generation falls back to the legacy in-process path
+     * that writes the fakes as a side effect of `compileKotlin*`.
      *
-     * **KMP support matrix (under the flag):**
+     * **KMP support matrix:**
      * - `commonMain` `@Fake` — generated and cache-correct (common producer task driving
      *   `KotlinMetadataCompiler`; no JVM/Android target required — KMP projects targeting only
      *   Native/JS/Wasm are covered too).
@@ -208,32 +209,31 @@ constructor(objects: ObjectFactory, private val project: Project) {
      * - Native platform `@Fake` — generated (via the in-process plugin); not cache-correct
      *   (`K2NativeCompiler` is not on the embeddable classpath, so it cannot be driven in a task).
      *
-     * **Default:** `false` (the existing in-process compiler-plugin path runs unchanged).
+     * **Default:** `true` (the cache-correct `FaktGenerateTask` path).
      *
-     * **Usage (build script):**
+     * **Opting out (build script):**
      *
      * ```kotlin
      * fakt {
-     *     useExperimentalGenerateTask.set(true)
+     *     useExperimentalGenerateTask.set(false)
      * }
      * ```
      *
-     * **Usage (Gradle property — flips the default for any project that hasn't set it
+     * **Opting out (Gradle property — flips the default for any project that hasn't set it
      * explicitly):**
      *
      * ```
-     * gradle build -Pfakt.useExperimentalGenerateTask=true
+     * gradle build -Pfakt.useExperimentalGenerateTask=false
      * ```
      *
      * The Gradle property wins over the extension when both are set, so
      * `-Pfakt.useExperimentalGenerateTask=false` always lets you opt out.
      *
-     * Experimental while the task-based path stabilizes. The cache-correct path is intended to
-     * become the default, with this property remaining as an explicit opt-out until the legacy
-     * in-process path is removed.
+     * The legacy in-process path remains reachable through this property until it is removed; the
+     * property name is kept for compatibility with build scripts that already set it.
      */
     public val useExperimentalGenerateTask: Property<Boolean> =
-        objects.property(Boolean::class.java).convention(false)
+        objects.property(Boolean::class.java).convention(true)
 
     /**
      * Source project to collect generated fakes from (collector mode).

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktExperimentalGenerateTaskWiringTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktExperimentalGenerateTaskWiringTest.kt
@@ -13,64 +13,48 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
 
 /**
- * BDD coverage for the experimental `fakt.useExperimentalGenerateTask` rollout switch (PR 3).
+ * BDD coverage for the `fakt.useExperimentalGenerateTask` switch that selects the cache-correct
+ * `FaktGenerateTask` path (the default) over the legacy in-process compiler-plugin path.
  *
  * End-to-end behaviour (per-compilation `FaktGenerateTask` registration,
  * `kotlin.srcDir(taskProvider)` wiring, KMP `dependsOn` ordering) requires the Kotlin Gradle Plugin
  * to be applied — not feasible inside `ProjectBuilder` because the KGP wiring is heavy. Those flows
- * are covered by the sample matrix in CI (`samples/jvm-single-module:build
- * -Pfakt.useExperimentalGenerateTask=true`); this suite focuses on the parts that are
- * unit-testable: extension defaults, property opt-in, and the resolvable configurations the worker
- * classpath rides on.
+ * are covered by the sample matrix in CI (`samples/jvm-single-module:build`, which now exercises
+ * the default); this suite focuses on the parts that are unit-testable: the extension default, the
+ * explicit opt-out, and the resolvable configurations the worker classpath rides on.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FaktExperimentalGenerateTaskWiringTest {
 
     @Test
-    fun `GIVEN plugin applied WHEN reading useExperimentalGenerateTask THEN defaults to false`() {
+    fun `GIVEN plugin applied WHEN reading useExperimentalGenerateTask THEN defaults to true`() {
         val project = ProjectBuilder.builder().build()
         project.pluginManager.apply("com.rsicarelli.fakt")
 
         val extension = project.extensions.getByType(FaktPluginExtension::class.java)
+
+        assertTrue(
+            extension.useExperimentalGenerateTask.get(),
+            "Default must be true so the cache-correct FaktGenerateTask path is what ships.",
+        )
+    }
+
+    @Test
+    fun `GIVEN extension WHEN setting useExperimentalGenerateTask to false THEN flag flips`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
+        val extension = project.extensions.getByType(FaktPluginExtension::class.java)
+
+        extension.useExperimentalGenerateTask.set(false)
 
         assertFalse(
             extension.useExperimentalGenerateTask.get(),
-            "Default must be false so the legacy in-process path stays the rollout target.",
+            "The extension must remain the explicit opt-out back to the legacy in-process path.",
         )
     }
 
     @Test
-    fun `GIVEN extension WHEN setting useExperimentalGenerateTask THEN flag flips`() {
-        val project = ProjectBuilder.builder().build()
-        project.pluginManager.apply("com.rsicarelli.fakt")
-        val extension = project.extensions.getByType(FaktPluginExtension::class.java)
-
-        extension.useExperimentalGenerateTask.set(true)
-
-        assertTrue(extension.useExperimentalGenerateTask.get())
-    }
-
-    @Test
-    fun `GIVEN flag false on apply WHEN evaluating THEN faktWorker faktCompiler configurations are NOT created`(
-        @TempDir tempDir: java.io.File
-    ) {
-        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
-        project.pluginManager.apply("com.rsicarelli.fakt")
-
-        (project as ProjectInternal).evaluate()
-
-        assertNull(
-            project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION),
-            "faktWorker should only be created when the flag is on — legacy path stays clean.",
-        )
-        assertNull(
-            project.configurations.findByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION),
-            "faktCompiler should only be created when the flag is on.",
-        )
-    }
-
-    @Test
-    fun `GIVEN flag set true via extension WHEN evaluating THEN faktWorker and faktCompiler configurations exist`(
+    fun `GIVEN flag set false on apply WHEN evaluating THEN faktWorker faktCompiler configurations are NOT created`(
         @TempDir tempDir: java.io.File
     ) {
         val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
@@ -78,15 +62,34 @@ class FaktExperimentalGenerateTaskWiringTest {
         project.extensions
             .getByType(FaktPluginExtension::class.java)
             .useExperimentalGenerateTask
-            .set(true)
+            .set(false)
+
+        (project as ProjectInternal).evaluate()
+
+        assertNull(
+            project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION),
+            "faktWorker must not be created when opted out — the legacy path stays clean.",
+        )
+        assertNull(
+            project.configurations.findByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION),
+            "faktCompiler must not be created when opted out.",
+        )
+    }
+
+    @Test
+    fun `GIVEN default configuration WHEN evaluating THEN faktWorker and faktCompiler configurations exist`(
+        @TempDir tempDir: java.io.File
+    ) {
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        project.pluginManager.apply("com.rsicarelli.fakt")
 
         (project as ProjectInternal).evaluate()
 
         val worker = project.configurations.findByName(FaktGradleSubplugin.WORKER_CONFIGURATION)
         val compiler =
             project.configurations.findByName(FaktGradleSubplugin.COMPILER_CLASSPATH_CONFIGURATION)
-        assertNotNull(worker, "faktWorker configuration must be created when flag=true.")
-        assertNotNull(compiler, "faktCompiler configuration must be created when flag=true.")
+        assertNotNull(worker, "faktWorker configuration must be created on the default path.")
+        assertNotNull(compiler, "faktCompiler configuration must be created on the default path.")
         assertTrue(worker.isCanBeResolved, "faktWorker must be resolvable for worker classpath.")
         assertFalse(
             worker.isCanBeConsumed,

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiringTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiringTest.kt
@@ -160,10 +160,16 @@ class FaktGenerateTaskWiringTest {
     }
 
     @Test
-    fun `GIVEN no producer registered WHEN a lint task exists THEN it gains no Fakt dependency`(
+    fun `GIVEN the legacy in-process path WHEN a lint task exists THEN it gains no Fakt dependency`(
         @TempDir tempDir: File
     ) {
-        val project = evaluatedJvmProject(tempDir)
+        // Opting out explicitly is what makes this the legacy path: the cache-correct path is the
+        // default, so an unconfigured project registers a producer during evaluation.
+        val project =
+            createJvmProject(tempDir).also {
+                it.faktExtension().useExperimentalGenerateTask.set(false)
+                it.evaluate()
+            }
 
         project.tasks.register("lintAnalyzeAndroidHostTest")
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.io.TempDir
  * Two harnesses:
  * - `ProjectBuilder` drives the public [FaktGradleSubplugin.applyToCompilation] /
  *   [FaktGradleSubplugin.isApplicable] seams directly with real compilations — covers the
- *   extension-set branch, the both-unset default, the KMP veto, and test-compilation skipping.
+ *   extension-set branch, the opted-out branch, the KMP veto, and test-compilation skipping.
  * - Gradle TestKit covers the `gradleProperty` branches: `ProjectBuilder` cannot inject Gradle
  *   properties (they come from start parameters), so a synthetic build passing `-P` flags is the
  *   only faithful seam. The TestKit builds only run `tasks --all` — configuration-time probing,
@@ -66,10 +66,11 @@ class FaktGradleSubpluginFlagResolutionTest {
     }
 
     @Test
-    fun `GIVEN flag unset WHEN applyToCompilation on JVM THEN returns legacy options`(
+    fun `GIVEN flag false via extension WHEN applyToCompilation on JVM THEN returns legacy options`(
         @TempDir tempDir: File
     ) {
         val project = createJvmProject(tempDir)
+        project.faktExtension().useExperimentalGenerateTask.set(false)
         project.evaluate()
 
         val options =
@@ -86,7 +87,7 @@ class FaktGradleSubpluginFlagResolutionTest {
                 "outputDir",
             ),
             keys,
-            "Extension unset + property unset must resolve to false and keep the legacy payload.",
+            "An explicit extension false must keep the legacy in-process payload.",
         )
         assertEquals("true", options.first { it.key == "enabled" }.value)
     }
@@ -138,6 +139,30 @@ class FaktGradleSubpluginFlagResolutionTest {
         assertTrue(
             project.tasks.names.contains("faktGenerateJvmMain"),
             "The drivable platform main must register a source-partitioned consumer task.",
+        )
+    }
+
+    @Test
+    fun `GIVEN single-target KMP WHEN applyToCompilation on the platform main THEN stays legacy and registers no task`() {
+        val project = createKmpProject()
+        project.getKotlinExtension().jvm()
+        project.evaluate()
+
+        val options =
+            project.faktSubplugin().applyToCompilation(project.kmpCompilation("jvm", "main")).get()
+
+        // A single-target KMP project never gets the per-source-set `commonMain` compilation, so
+        // no common producer can exist. Routing the lone platform main to a source-partitioned
+        // consumer would drop every `@Fake` declared in commonMain, so the whole project stays on
+        // the in-process plugin: correct, just not cache-correct.
+        assertTrue(
+            options.size > 1,
+            "Single-target KMP must keep the full legacy payload; keys: ${options.map { it.key }}",
+        )
+        assertEquals("true", options.first { it.key == "enabled" }.value)
+        assertFalse(
+            project.tasks.names.any { it.startsWith("faktGenerate") },
+            "No FaktGenerateTask may be registered for a single-target KMP project.",
         )
     }
 
@@ -272,30 +297,63 @@ class FaktGradleSubpluginFlagResolutionTest {
     }
 
     @Test
-    fun `GIVEN gradle property yes WHEN building THEN treated as false and no faktGenerate task`(
+    fun `GIVEN no property and no extension WHEN building THEN faktGenerateJvmMain registered`(
+        @TempDir projectDir: File
+    ) {
+        setupKotlinJvmFaktProject(projectDir)
+
+        val result = listTasks(projectDir)
+
+        assertTrue(
+            result.output.contains("faktGenerateJvmMain"),
+            "The cache-correct path is the default — an unconfigured project must get the task.",
+        )
+    }
+
+    @Test
+    fun `GIVEN extension false and no property WHEN building THEN no faktGenerate task`(
+        @TempDir projectDir: File
+    ) {
+        setupKotlinJvmFaktProject(
+            projectDir,
+            extensionBlock =
+                "extensions.getByType(com.rsicarelli.fakt.gradle.FaktPluginExtension::class.java)" +
+                    ".useExperimentalGenerateTask.set(false)",
+        )
+
+        val result = listTasks(projectDir)
+
+        assertFalse(
+            result.output.contains("faktGenerate"),
+            "The extension must remain a working opt-out back to the legacy in-process path.",
+        )
+    }
+
+    @Test
+    fun `GIVEN gradle property yes WHEN building THEN falls back to the extension default and task registered`(
         @TempDir projectDir: File
     ) {
         setupKotlinJvmFaktProject(projectDir)
 
         val result = listTasks(projectDir, "-Pfakt.useExperimentalGenerateTask=yes")
 
-        assertFalse(
-            result.output.contains("faktGenerate"),
-            "Only strict 'true'/'false' parse — 'yes' must fall back to false.",
+        assertTrue(
+            result.output.contains("faktGenerateJvmMain"),
+            "Only strict 'true'/'false' parse — 'yes' must fall through to the extension default.",
         )
     }
 
     @Test
-    fun `GIVEN gradle property empty string WHEN building THEN treated as false and no faktGenerate task`(
+    fun `GIVEN gradle property empty string WHEN building THEN falls back to the extension default and task registered`(
         @TempDir projectDir: File
     ) {
         setupKotlinJvmFaktProject(projectDir)
 
         val result = listTasks(projectDir, "-Pfakt.useExperimentalGenerateTask=")
 
-        assertFalse(
-            result.output.contains("faktGenerate"),
-            "Empty property value must fall back to false, not crash or enable the path.",
+        assertTrue(
+            result.output.contains("faktGenerateJvmMain"),
+            "Empty property value must fall through to the extension default, not crash.",
         )
     }
 

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGradleSubpluginFlagResolutionTest.kt
@@ -167,6 +167,64 @@ class FaktGradleSubpluginFlagResolutionTest {
     }
 
     @Test
+    fun `GIVEN multi-target KMP WHEN applyToCompilation on the legacy metadata main THEN suppressed and registers no task`() {
+        val project = createKmpProject()
+        project.getKotlinExtension().jvm()
+        project.getKotlinExtension().linuxX64()
+        project.faktExtension().useExperimentalGenerateTask.set(true)
+        project.evaluate()
+
+        val options =
+            project
+                .faktSubplugin()
+                .applyToCompilation(project.kmpCompilation("metadata", "main"))
+                .get()
+
+        // The metadata target exposes the per-source-set `commonMain` compilation (the producer)
+        // AND this legacy `main` compilation, both platformType `common`. Turning the second into a
+        // producer would emit the common fakes twice into the same directory, so it is suppressed —
+        // the in-process plugin is off, but no task owns it either.
+        assertEquals(
+            1,
+            options.size,
+            "A suppressed compilation gets enabled=false only; keys: ${options.map { it.key }}",
+        )
+        assertEquals("false", options.single { it.key == "enabled" }.value)
+        assertFalse(
+            project.tasks.names.contains("faktGenerateMetadataMain"),
+            "The legacy metadata main compilation must not register a producer of its own; " +
+                "fakt tasks: ${project.tasks.names.filter { it.startsWith("faktGenerate") }}",
+        )
+    }
+
+    @Test
+    fun `GIVEN single-target KMP WHEN applyToCompilation on the legacy metadata main THEN stays legacy and registers no task`() {
+        val project = createKmpProject()
+        project.getKotlinExtension().jvm()
+        project.evaluate()
+
+        val options =
+            project
+                .faktSubplugin()
+                .applyToCompilation(project.kmpCompilation("metadata", "main"))
+                .get()
+
+        // In a single-target project this compilation is the only one carrying `commonMain` as its
+        // default source set, which makes it a tempting producer — but KGP resolves an EMPTY
+        // compile classpath for it, so KotlinMetadataCompiler cannot be driven over it (it fails
+        // with "unresolved reference 'Fake'"). The whole project stays on the in-process plugin.
+        assertTrue(
+            options.size > 1,
+            "Single-target KMP keeps the full legacy payload; keys: ${options.map { it.key }}",
+        )
+        assertEquals("true", options.first { it.key == "enabled" }.value)
+        assertFalse(
+            project.tasks.names.any { it.startsWith("faktGenerate") },
+            "No FaktGenerateTask may be registered anywhere in a single-target KMP project.",
+        )
+    }
+
+    @Test
     fun `GIVEN flag true AND non-drivable KMP platform main WHEN applyToCompilation THEN returns legacy options and registers no task`() {
         val project = createKmpProject()
         project.getKotlinExtension().jvm()

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktKotlinSourceSetModelTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktKotlinSourceSetModelTest.kt
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 Rodrigo Sicarelli
+// SPDX-License-Identifier: Apache-2.0
+package com.rsicarelli.fakt.gradle
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Pins the full truth table of [hasReadableKotlinSourceSets], the pure predicate that keeps the
+ * cache-correct path off projects whose Kotlin source sets it cannot read.
+ *
+ * AGP 9 ships built-in Kotlin support and rejects KGP's `org.jetbrains.kotlin.android`. There the
+ * `KotlinCompilation`s handed to the subplugin expose `KotlinSourceSet`s whose `srcDirs` are empty
+ * — AGP keeps sources in its own variant model — so a `FaktGenerateTask` producer would resolve
+ * zero sources, run as NO-SOURCE and silently generate nothing. Such projects must stay on the
+ * in-process plugin. Locked end-to-end by the `samples/compat-agp/agp-9.0` CI cell; this table is
+ * the unit-level guard.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaktKotlinSourceSetModelTest {
+
+    @Test
+    fun `GIVEN non-Android project WHEN no kotlin-android plugin THEN source sets are readable`() {
+        assertTrue(
+            hasReadableKotlinSourceSets(hasAndroidPlugin = false, hasKotlinAndroidPlugin = false),
+            "A JVM or KMP project always populates the KGP source-set model.",
+        )
+    }
+
+    @Test
+    fun `GIVEN Android project WHEN kotlin-android plugin applied THEN source sets are readable`() {
+        assertTrue(
+            hasReadableKotlinSourceSets(hasAndroidPlugin = true, hasKotlinAndroidPlugin = true),
+            "AGP 8.x + KGP populates srcDirs, so the cache-correct producer can read them.",
+        )
+    }
+
+    @Test
+    fun `GIVEN Android project WHEN kotlin-android plugin absent THEN source sets are NOT readable`() {
+        assertFalse(
+            hasReadableKotlinSourceSets(hasAndroidPlugin = true, hasKotlinAndroidPlugin = false),
+            "AGP built-in Kotlin leaves srcDirs empty — the producer would generate nothing.",
+        )
+    }
+
+    @Test
+    fun `GIVEN non-Android project WHEN kotlin-android plugin somehow applied THEN source sets are readable`() {
+        assertTrue(
+            hasReadableKotlinSourceSets(hasAndroidPlugin = false, hasKotlinAndroidPlugin = true),
+            "Only the Android case can lack the source-set model; everything else has one.",
+        )
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtensionDefaultsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktPluginExtensionDefaultsTest.kt
@@ -12,9 +12,10 @@ import org.junit.jupiter.api.TestInstance
 /**
  * Pins the [FaktPluginExtension] property defaults that no other suite covers.
  *
- * `enabled` and `enableCallHistory` defaults live in [FaktGradleSubpluginTest];
- * `useExperimentalGenerateTask` default lives in [FaktExperimentalGenerateTaskWiringTest]. This
- * suite covers the remaining conventions so a default flip can never land silently.
+ * `enabled` and `enableCallHistory` defaults live in [FaktGradleSubpluginTest]; the
+ * `useExperimentalGenerateTask` default (`true` — the cache-correct path) lives in
+ * [FaktExperimentalGenerateTaskWiringTest]. This suite covers the remaining conventions so a
+ * default flip can never land silently.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FaktPluginExtensionDefaultsTest {

--- a/samples/kmp-android-lint/build.gradle.kts
+++ b/samples/kmp-android-lint/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 }
 
 fakt {
-    // The experimental generate-task path (also set in gradle.properties) registers
-    // `faktGenerateMetadataCommonMain`, reproducing the reporter's configuration.
+    // The generate-task path (Fakt's default) registers `faktGenerateMetadataCommonMain`,
+    // reproducing the reporter's configuration.
     logLevel.set(com.rsicarelli.fakt.compiler.api.LogLevel.INFO)
 }

--- a/samples/kmp-android-lint/gradle.properties
+++ b/samples/kmp-android-lint/gradle.properties
@@ -10,7 +10,7 @@ kotlin.mpp.applyDefaultHierarchyTemplate=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 
-# Reproduce issue #129: the experimental generate-task path registers a FaktGenerateTask
+# Reproduce issue #129: the generate-task path (Fakt's default) registers a FaktGenerateTask
 # (faktGenerateMetadataCommonMain) whose @OutputDirectory feeds commonTest. Under Gradle 9.6+, AGP
-# lint fails unless that dir declares the task as its builder.
-fakt.useExperimentalGenerateTask=true
+# lint fails unless that dir declares the task as its builder. Nothing is pinned here on purpose —
+# the sample must exercise the shipped default.


### PR DESCRIPTION
## Description

Flips `fakt.useExperimentalGenerateTask` from `false` to `true` (backlog **P8**, issue #79). Fakes are generated by cacheable `FaktGenerateTask`s instead of as a side effect of `compileKotlin*`, so the generated `.kt` files are declared task outputs and a warm build cache restores them along with the compilation that uses them.

The property name is unchanged — no API-dump churn, no migration for build scripts that already set it — and becomes the documented opt-out: `useExperimentalGenerateTask.set(false)` or `-Pfakt.useExperimentalGenerateTask=false` selects the legacy in-process path, which stays reachable until P9 removes it.

**Ready to merge:** rebased onto `73033dd` (current `main`, including merged #138), 0 commits behind, no conflicts, CI fully green.

## Commits

| Commit | What |
|---|---|
| `bdaa86b` | the flip itself + docs |
| `5b1f144` | AGP built-in Kotlin → legacy routing (fixes the AGP 9.0 cell) |
| `7458d76` | metadata-compilation routing coverage (tests only) |
| `a885a69` | legacy-path test fix surfaced by the rebase (tests only) |

## Two project shapes the flip exposed

Both would have silently generated **zero fakes** under the new default. Both now route to `LEGACY` — the in-process path, i.e. exactly their pre-PR behaviour: correct output, just not cache-correct. Neither is a regression introduced here; the flip is what made them reachable.

**1. Single-target KMP** (`kotlin { jvm() }` and nothing else). Kotlin never creates the per-source-set `commonMain` compilation for these; it exposes only the legacy metadata `main` compilation, which carries `commonMain` as its default source set but resolves an *empty* compile classpath, so `KotlinMetadataCompiler` cannot be driven over it. The lone platform main is a source-partitioned consumer emitting only its own source set, so every `@Fake` in `commonMain` was dropped. The whole `samples/compat/*` matrix has this shape and was red before the fix.

Detection counts non-`metadata` targets rather than looking the compilation up: KGP creates the metadata target's per-source-set compilations *after* resolving subplugins for every platform main, so the lookup reports "absent" for multi-target projects too. Verified by instrumenting the plugin against `kmp-multi-target`.

**2. Android modules on AGP's built-in Kotlin** (AGP 9+, which rejects `org.jetbrains.kotlin.android`). The `KotlinCompilation`s handed to `applyToCompilation` carry `KotlinSourceSet`s whose `srcDirs` are empty — AGP keeps sources in its own variant model — so the producer resolved zero sources and ran `NO-SOURCE`. Measured on `samples/compat-agp/agp-9.0`: `srcDirs=[]` on every compilation even at `projectsEvaluated`, while the AGP 8.x + KGP cells report real directories.

Detected by plugin id, never by probing `srcDirs` (unreadable at routing time for every project — an emptiness probe would send healthy KGP projects down the legacy path too). Android modules applying the Kotlin Android plugin — every AGP 8.x build — keep the cache-correct path, confirmed by the 8.11/8.12 cells still registering their `faktGenerate` task.

**Also in this PR**
- Samples inherit the new default; the now-redundant `fakt.useExperimentalGenerateTask=true` pin in `kmp-android-lint` is removed so the sample exercises the shipped default.
- `.github/scripts/cache-correctness-check.sh` drops its hardcoded `-P` flag, so the issue-#79 contract is asserted against the configuration users actually get.
- Public docs (`plugin-configuration.md`, `get-started`, `performance`) and the internal architecture notes are rewritten around the new default, including both fallback shapes.

## Related Issue
Relates to #79 (P8 — flip default). P9 (remove the legacy in-process path) remains open.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

### CI

**33/33 checks green** on `a885a69`, including the aggregate `CI Summary`.

For `Compat / KMP+Android lint` I checked the job log rather than the green tick, because #138 added a second invocation to that job and a silently-skipped step would still look green. The log shows both invocations ran (2× `BUILD SUCCESSFUL`, 0 failures) and `faktGenerateMetadataCommonMain` present in **both** task graphs — so the lint job is now exercising real generated sources instead of a directory nothing produced.

### Verified locally

All green with no flag passed anywhere. An Android SDK was installed in the working environment, so the Android matrix is covered locally too.

| Check | Result |
|---|---|
| `./gradlew test` (all modules), `apiCheck`, `detekt` | pass — API dump unchanged |
| `jvm-single-module`, `jvm-test-fixtures` | `build` pass |
| `kmp-single-module`, `kmp-multi-target`, `kmp-no-jvm`, `kmp-multi-module` | `jvmTest` / `linuxX64Test` / JS + Wasm compile pass |
| `fake-publishing` (publisher → consumer) | pass |
| `android-single-module`, `android-test-fixtures` | `build` pass |
| `compat-agp` AGP 8.11 / 8.12 / 9.0 | `testDebugUnitTest` pass — 8.11/8.12 still register their `faktGenerate` task |
| `kmp-android-lint` | both CI invocations pass, with the sample's pin removed |
| Compat matrix, Kotlin 2.2.0 → 2.4.10 (8 cells) | pass |
| Cache contracts: `kmp-multi-target`, `kmp-no-jvm`, `kmp-multi-module`, `fake-publishing` | all producers FROM-CACHE, platform fakes present |
| Opt-out: `-Pfakt.useExperimentalGenerateTask=false` | no `faktGenerate*` tasks, fakes still generated in-process |

Remaining local gap: JS/Wasm *test* runs need npm/yarn network access unavailable in that environment — their *compile* tasks were exercised, and CI covers the rest.

### The rebase caught a cross-PR interaction

`a885a69` fixes a test #138 introduced. Its premise — "no producer registered" — depended on the flag defaulting to `false`; this PR inverts that, so evaluating the project now registers a producer and the precondition became unreachable. The test now selects the legacy path explicitly and is renamed to state that precondition rather than assume it. Neither PR could have caught this alone.

### Tests

- `FaktKotlinSourceSetModelTest` — truth table for the AGP source-set-model predicate, following the existing `shouldEnableTestFixtures` pattern (AGP is not on the gradle-plugin test classpath, so the `agp-9.0` CI cell is the end-to-end lock for that path).
- `FaktGradleSubpluginFlagResolutionTest` — single-target KMP routing, plus the two previously-uncovered metadata-compilation branches: SUPPRESS in multi-target, LEGACY in single-target.
- Default-value and property-branch suites updated for the flip: a non-strict property value like `-P…=yes` now falls through to a `true` convention, so those tests assert the task *is* registered.

### Out of scope

`./gradlew test spotlessCheck` fails locally on a Spotless configuration-cache bug — tracked separately in #139, present on `main`, not caused by this PR, and not hit by CI (Spotless runs in its own job). Deliberately not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWSCwKrukTjA8b59QdtiyB