### PR TITLE
fix(gradle): declare the fake generator to AGP lint tasks

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -328,11 +328,19 @@ jobs:
 
       # End-to-end smoke test for #129: runs AGP lint on a KMP+Android module pinned to its OWN
       # Gradle 9.6.1 wrapper (the root wrapper is older), exercising lintAnalyzeAndroidHostTest over
-      # the commonTest generated source dir. Proves the fix builds and lints cleanly under 9.6.1.
-      # The deterministic regression guard is the SimplifiedSourceSetConfigurationTest unit test.
+      # the commonTest generated source dir.
       - name: Run AGP lint under Gradle 9.6.1
         working-directory: samples/kmp-android-lint
         run: ./gradlew lint --no-daemon
+
+      # `lint` alone used to leave faktGenerateMetadataCommonMain out of the task graph, so the step
+      # above linted a directory nothing had produced and could not catch the implicit-dependency
+      # failure at all. `build` pulls the generator in through the compile tasks, which is the graph
+      # that reproduces it. Keep both: the first pins the lint-only graph, this one the full graph.
+      # The deterministic regression guard is FaktGenerateTaskWiringTest's lint-ordering tests.
+      - name: Run AGP lint with the generator in the task graph
+        working-directory: samples/kmp-android-lint
+        run: ./gradlew clean build lint --no-daemon
 
   ci-summary:
     name: CI Summary

--- a/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
+++ b/gradle-plugin/src/main/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiring.kt
@@ -69,8 +69,7 @@ internal object FaktGenerateTaskWiring {
 
         // applyToCompilation fires before afterEvaluate, so the configurations may not exist yet
         // by the time we land here. Idempotent helper makes the call safe to repeat.
-        val subplugin = getSubpluginInstance(project)
-        subplugin.ensureFaktConfigurations(project)
+        getSubpluginInstance(project).ensureFaktConfigurations(project)
 
         // A KMP `commonMain` producer writes to the canonical `commonTest` directory so the
         // in-process plugin riding a non-drivable platform compilation (Native/JS/Wasm) finds the
@@ -129,11 +128,26 @@ internal object FaktGenerateTaskWiring {
                 task.scratchDir.set(scratchDir)
             }
 
+        wireGeneratedDirConsumers(project, kotlinCompilation, extension, taskProvider)
+    }
+
+    /**
+     * Points everything that reads the task's `@OutputDirectory` at the task that fills it: the
+     * matching test source set, the KMP cross-target `dependsOn` chain, and AGP's lint tasks.
+     */
+    private fun wireGeneratedDirConsumers(
+        project: Project,
+        kotlinCompilation: KotlinCompilation<*>,
+        extension: FaktPluginExtension,
+        taskProvider: TaskProvider<FaktGenerateTask>,
+    ) {
         // Resolved once: honours `useGradleTestFixtures` AND the `java-test-fixtures` plugin being
         // applied (warns and falls back to `test` otherwise), matching the legacy path's semantics.
-        val useTestFixtures = subplugin.resolveTestFixturesMode(project, extension)
+        val useTestFixtures =
+            getSubpluginInstance(project).resolveTestFixturesMode(project, extension)
         wireTestSrcDir(project, kotlinCompilation, taskProvider, useTestFixtures)
         wireKmpDependsOnCommonMain(project, kotlinCompilation, taskProvider)
+        wireAndroidLintOrdering(project, taskProvider)
     }
 
     /**
@@ -237,6 +251,39 @@ internal object FaktGenerateTaskWiring {
         val json = Json { prettyPrint = false }
         return json.encodeToString(SourceSetContext.serializer(), context)
     }
+}
+
+/**
+ * Makes AGP's lint tasks depend on the generator that produces the sources they analyse.
+ *
+ * The generated directory reaches a Kotlin compilation through a `builtBy`-carrying
+ * `FileCollection`, which is enough for `compileKotlin*`. AGP's lint tasks read the same directory
+ * through the Android variant's own source model, which does **not** carry that task dependency, so
+ * `lintAnalyze*` sees an input inside `FaktGenerateTask`'s `@OutputDirectory` with no path to it
+ * and Gradle fails the build:
+ * ```
+ * Task ':lintAnalyzeAndroidHostTest' uses this output of task
+ * ':faktGenerateMetadataCommonMain' without declaring an explicit or implicit dependency.
+ * ```
+ *
+ * The failure only surfaces when the generator is actually in the task graph — `lint` alone leaves
+ * it out (and then lints a directory nothing produced), while `build lint` pulls it in via the
+ * compile tasks. Declaring the dependency here fixes both: lint now waits for the fakes, so it also
+ * stops analysing a phantom directory.
+ *
+ * Only the cache-correct path needs this. The legacy in-process path writes the fakes as a side
+ * effect of `compileKotlin*` with no declared output, so Gradle has nothing to validate.
+ *
+ * Safe under Gradle 9 Project Isolation: no `afterEvaluate` and no task-graph reads — the match is
+ * lazy and `configureEach` only runs for lint tasks that are actually realized.
+ */
+private fun wireAndroidLintOrdering(
+    project: Project,
+    taskProvider: TaskProvider<FaktGenerateTask>,
+) {
+    project.tasks
+        .matching { it.name.startsWith("lint") }
+        .configureEach { lintTask -> lintTask.dependsOn(taskProvider) }
 }
 
 private fun taskNameFor(targetName: String, compilationName: String): String =

--- a/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiringTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/rsicarelli/fakt/gradle/FaktGenerateTaskWiringTest.kt
@@ -47,6 +47,12 @@ class FaktGenerateTaskWiringTest {
     private fun Project.faktExtension(): FaktPluginExtension =
         extensions.getByType(FaktPluginExtension::class.java)
 
+    /** Names of every task the project's lint tasks depend on. */
+    private fun Project.lintTaskDependencyNames(): List<String> =
+        tasks.getByName("lintAnalyzeAndroidHostTest").taskDependencies.getDependencies(null).map {
+            it.name
+        }
+
     /**
      * commonMain is a producer; a drivable platform main (jvmMain) is a source-partitioned
      * consumer.
@@ -105,6 +111,69 @@ class FaktGenerateTaskWiringTest {
         FaktGenerateTaskWiring.registerProducer(project, compilation, extension)
 
         assertNotNull(project.tasks.findByName("faktGenerateJvmMain"))
+    }
+
+    @Test
+    fun `GIVEN lint task registered BEFORE the producer WHEN register THEN lint depends on the generator`(
+        @TempDir tempDir: File
+    ) {
+        val project = evaluatedJvmProject(tempDir)
+        // Stands in for AGP's lintAnalyze*/lintReport*, which ProjectBuilder cannot create without
+        // the Android Gradle plugin on the test classpath. Only the name matters to the wiring.
+        project.tasks.register("lintAnalyzeAndroidHostTest")
+
+        FaktGenerateTaskWiring.registerProducer(
+            project,
+            project.jvmCompilation("main"),
+            project.faktExtension(),
+        )
+
+        assertTrue(
+            project.lintTaskDependencyNames().contains("faktGenerateJvmMain"),
+            "AGP lint reads the generated dir through the Android variant model, which carries no " +
+                "task dependency; without an explicit one Gradle fails lintAnalyze* with " +
+                "'uses this output ... without declaring an explicit or implicit dependency'. " +
+                "deps: ${project.lintTaskDependencyNames()}",
+        )
+    }
+
+    @Test
+    fun `GIVEN lint task registered AFTER the producer WHEN register THEN lint still depends on the generator`(
+        @TempDir tempDir: File
+    ) {
+        val project = evaluatedJvmProject(tempDir)
+
+        FaktGenerateTaskWiring.registerProducer(
+            project,
+            project.jvmCompilation("main"),
+            project.faktExtension(),
+        )
+        // AGP creates its lint tasks on its own schedule, so the wiring must not depend on the
+        // producer being registered first — `matching {}.configureEach {}` is live for both orders.
+        project.tasks.register("lintAnalyzeAndroidHostTest")
+
+        assertTrue(
+            project.lintTaskDependencyNames().contains("faktGenerateJvmMain"),
+            "The lint dependency must not depend on task-registration order; " +
+                "deps: ${project.lintTaskDependencyNames()}",
+        )
+    }
+
+    @Test
+    fun `GIVEN no producer registered WHEN a lint task exists THEN it gains no Fakt dependency`(
+        @TempDir tempDir: File
+    ) {
+        val project = evaluatedJvmProject(tempDir)
+
+        project.tasks.register("lintAnalyzeAndroidHostTest")
+
+        // Legacy in-process path: fakes are a side effect of compileKotlin* with no declared
+        // output, so there is nothing for Gradle to validate and nothing to wait for.
+        assertTrue(
+            project.lintTaskDependencyNames().none { it.startsWith("faktGenerate") },
+            "Without a FaktGenerateTask, lint must stay free of Fakt dependencies; " +
+                "deps: ${project.lintTaskDependencyNames()}",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes the implicit-dependency failure in #137. AGP's lint tasks read the `FaktGenerateTask` `@OutputDirectory` through the **Android variant's own source model**, which carries no task dependency. As soon as the generator is in the task graph, Gradle fails:

```
Task ':lintAnalyzeAndroidHostTest' uses this output of task
':faktGenerateMetadataCommonMain' without declaring an explicit or implicit dependency.
```

The `builtBy` added in #129 is present and correct — I verified at `taskGraph.whenReady` that `commonTest.kotlin.buildDependencies == [faktGenerateMetadataCommonMain]` in the *failing* run too. It reaches `compileKotlin*`; `lintAnalyze*` is a second consumer arriving by a different route, so #129/#131 were not wrong, just incomplete.

**Pass vs fail is decided by the task graph, not the Gradle version.** The full 2×2 on `main`:

| Gradle | Tasks | Before | After |
|---|---|---|---|
| 9.6.1 (sample wrapper) | `clean lint` | ✅ | ✅ |
| 9.6.1 (sample wrapper) | `clean build lint` | ❌ | ✅ |
| 9.5.1 (root wrapper) | `clean lint` | ✅ | ✅ |
| 9.5.1 (root wrapper) | `clean build lint` | ❌ | ✅ |

`lint` alone leaves the generator out of the graph, so Gradle validates nothing — and lint analyses a directory nothing produced. `build` pulls it in via the compile tasks and the validation fires.

**The fix** makes lint tasks depend on the generator — Gradle's own suggested remedy for this diagnostic. It also means `lint` alone now pulls the generator into the graph, so the sample lints real generated sources instead of a phantom directory. Only the cache-correct path needs it: the legacy in-process path writes fakes with no declared output, so there is nothing to validate.

Implemented as a lazy `tasks.matching { }.configureEach { }`, matching the existing `wireLegacyHybridOrdering` convention in the same file — no `afterEvaluate`, no task-graph reads, safe under Gradle 9 Project Isolation.

**CI could not have caught this.** The `Compat / KMP+Android lint` job ran `lint` only. This PR adds the `clean build lint` invocation that reproduces the failure, keeping the existing step so both graphs stay pinned.

## Related Issue
Fixes #137

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor/Performance/Build

## Pre-Submission Checklist
- [x] Code formatted: `./gradlew spotlessApply`
- [x] Linter passing: `./gradlew lintKotlin`
- [x] Static analysis: `./gradlew detekt`
- [x] Tests added/updated and passing: `./gradlew test`
- [x] Generated code compiles (verified with sample project)
- [x] Updated documentation if needed
- [x] No breaking changes OR breaking changes documented

## Additional Context

**Independent of PR #136.** Branched from `main`; the defect reproduces on `main` today and touches a file #136 does not. Either can merge first.

**Tests** — three cases added to `FaktGenerateTaskWiringTest`, verified red before the fix and green after (I temporarily reverted the fix to confirm the first two actually fail, rather than assuming):

| Test | Purpose |
|---|---|
| lint task registered **before** the producer | the dependency is wired |
| lint task registered **after** the producer | wiring is order-independent — AGP creates lint tasks on its own schedule |
| **no** producer registered | legacy path gains no phantom Fakt dependency |

**Verified locally** (Android SDK installed in the working environment):

| Check | Result |
|---|---|
| `samples/kmp-android-lint` — all four 2×2 cells | pass |
| `./gradlew test` (all modules), `detekt`, `:gradle-plugin:apiCheck`, `spotlessApply` | pass — API dump unchanged |
| `android-single-module`, `android-test-fixtures` | `build` pass |
| `jvm-single-module`, `jvm-test-fixtures` | `build` pass |
| `kmp-multi-target`, `kmp-no-jvm` | tests + JS compile pass |
| Cache contracts: `kmp-multi-target`, `kmp-no-jvm`, `kmp-multi-module` | all producers FROM-CACHE, platform fakes present |

The cache contracts matter here: the new dependency edge touches the shared registration path, so a stray edge would surface as a cache-key or FROM-CACHE regression.

Detekt pushed back twice while shaping this (`LongMethod`, then `TooManyFunctions`), so the post-registration wiring is grouped into `wireGeneratedDirConsumers` and the new helper sits at file top level alongside `taskNameFor` / `shouldWireGeneratedDir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWSCwKrukTjA8b59QdtiyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWSCwKrukTjA8b59QdtiyB)_